### PR TITLE
Add Config settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,10 @@ dmypy.json
 # Other Virtual Envs.
 .venv*/
 
+# Development Configuration
+config/
+internal.db
+
 # Created by https://www.gitignore.io/api/vim
 # Edit at https://www.gitignore.io/?templates=vim
 

--- a/runserver.py
+++ b/runserver.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
+import os
+from pathlib import Path
+
 from trendlines.app_factory import create_app
 
 PORT = 5001
+
+# Load our configuration. We're using pathlib and `.resolve()` because
+# Flask's working dir is src/trendlines and uses that when running
+# `app.config.from_envvar`, so the path it attemps to load is
+# `/proj_folder/src/trendlines/config/localhost.cfg` if `cfg_file` is not
+# absolute.
+cfg_file = Path('./config/localhost.cfg')
+os.environ['TRENDLINES_CONFIG_FILE'] = str(cfg_file.resolve())
 
 app = create_app()
 app.run(debug=True, port=PORT, use_reloader=True)

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -11,6 +11,9 @@ def create_app():
     """
 
     app = Flask(__name__)
+    app.config.from_object('trendlines.default_config')
+    app.config.from_envvar("TRENDLINES_CONFIG_FILE", silent=True)
+    # TODO: Log/warn if from_envvar fails
 
     app.register_blueprint(routes.pages)
     app.register_blueprint(routes.api)

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -19,7 +19,7 @@ def create_app():
     app.register_blueprint(routes.api)
 
     # Create the database file and populate initial tables if needed.
-    create_db()
+    create_db(app.config['DATABASE'])
 
     # If I redesign the architecture a bit, then these could be moved so
     # that they only act on the `api` blueprint instead of the entire app.
@@ -52,13 +52,19 @@ def create_app():
     return app
 
 
-def create_db():
+def create_db(name):
     """
     Create the database and the tables.
 
     Does nothing if the tables already exist. Well, techinically it just
     connects and disconnects - ``create_tables`` is a noop.
+
+    Parameters
+    ----------
+    name : str
+        The name of the database, as given by ``app.config['DATABASE']``.
     """
+    orm.db.init(name, pragmas=orm.DB_OPTS)
     orm.db.connect()
     tables = [
         orm.Metric,

--- a/src/trendlines/default_config.py
+++ b/src/trendlines/default_config.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Default configuration settings.
+
+These settings are suitable for a locally-run production-like
+environment using SQLite.
+
+When converting to a production environment, the only *requirement* is to
+change the value of SECRET_KEY. Everything else should be suitable for
+running in production. I hope.
+"""
+
+# What database to use. Valid options are: "sqlite"
+DB_TYPE = "sqlite"
+
+# The database file to use. Ignored if DB_TYPE is not "sqlite"
+DATABASE = "./internal.db"
+
+# Flask Builtins ################################
+DEBUG = False
+TESTING = False
+MAX_CONTENT_LENGTH = 16 * 1024 * 1024   # 16MB
+SECRET_KEY = b"change me"

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -17,7 +17,7 @@ DB_OPTS = {
     'synchronous': 0,
 }
 
-db = SqliteDatabase('internal.db', pragmas=DB_OPTS)
+db = SqliteDatabase(None)
 
 
 class DataModel(Model):


### PR DESCRIPTION
This MR adds a `default_config.py` file and creates a way for users to override the default settings.

For now, the only setting that *actually* gets applied is the database name. I've added this because it turns out it's needed (or at least *probably* needed...) to get unit tests up and running.