### PR TITLE
Add simple CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: xenial
+
 python:
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+
+notifications:
+  email: false
+
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+  - pip install -e .
+
+script:
+  - pytest -ra

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple, lightweight alternative to [Graphite](https://graphiteapp.org).
 
+[![Build Status](https://travis-ci.org/dougthor42/trendlines.svg?branch=master)](https://travis-ci.org/dougthor42/trendlines)
+
 
 ## What is Trendlines?
 


### PR DESCRIPTION
This PR adds simple CI using Travis-CI. All the CI does right now is run tests, but it will eventually handle pushing to PyPI, building a docker image, recording coverage on Coveralls.io, etc.

Closes #10.