### PR TITLE
Rename routes.get_data to routes.format_data

### DIFF
--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -36,7 +36,8 @@ def plot(metric=None):
     if metric is None:
         return "Need a metric, friend!"
 
-    data = get_data(metric)
+    data = db.get_data(metric)
+    data = format_data(data)
     if len(data) == 0:
         return "Metric '{}' wasn't found. No data, maybe?".format(metric)
 
@@ -73,22 +74,20 @@ def add():
     return msg, 201
 
 
-# TODO: Rename this function. It's too easy to get confused with db.get_data
-def get_data(metric):
+def format_data(data):
     """
-    Helper function: query data, format for template consumption.
+    Helper function: format data for template consumption.
 
     Parameters
     ----------
-    metric : str
-        The metric name to get data for.
+    data : :class:`peewee.ModelSelect`
+        The data as returned by :func:`db.get_data`
 
     Returns
     -------
     data : dict
         Dictionary of data where ``timestamp`` is a POSIX integer timestamp.
     """
-    data = db.get_data(metric)
     data = [{'timestamp': row.timestamp.timestamp(),
              'value': row.value,
              'id': row.datapoint_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,14 @@ def populated_db():
 
 
 @pytest.fixture
+def raw_data(app, populated_db):
+    """
+    Provide the raw data as returned by :func:`db.get_data`.
+    """
+    return db.get_data("foo")
+
+
+@pytest.fixture
 def client(app):
     """
     A test client.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -47,5 +47,19 @@ def test_api_add_with_missing_key(client):
     assert b"Missing required key. Required keys are:" in rv.data
 
 
-def test_get_data():
-    pass
+def test_format_data(raw_data):
+    rv = routes.format_data(raw_data)
+    assert isinstance(rv, dict)
+    assert len(rv) == 1
+    assert 'rows' in rv.keys()
+    assert isinstance(rv['rows'], list)
+    assert len(rv['rows']) == 4
+    data_0 = rv['rows'][0]
+    assert isinstance(data_0, dict)
+    # Why don't I just use an expected dict here? Because I haven't bothered
+    # to freeze time on the `conftest.populated_db` fixture yet.
+    assert "timestamp" in data_0.keys()
+    assert "value" in data_0.keys()
+    assert "id" in data_0.keys()
+    assert "n" in data_0.keys()
+    assert data_0['value'] == 15


### PR DESCRIPTION
Renames `routes.get_data` to `routes.format_data`, and updates the call signature and docstring accordingly.

Also adds a test for that function specifically (previously it was implicitly tested).