### PR TITLE
Collapsing tree

### DIFF
--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -28,7 +28,8 @@ def index():
 
     Displays a list of all the known metrics with links.
     """
-    data = db.get_metrics()
+    raw_data = db.get_metrics()
+    data = utils.build_jstree_data(m.name for m in raw_data)
     return render_template("trendlines/index.html", data=data)
 
 

--- a/src/trendlines/templates/trendlines/index.html
+++ b/src/trendlines/templates/trendlines/index.html
@@ -1,11 +1,43 @@
 {% extends "trendlines/layout.html" %}
 
 {% block body %}
-<ul>
-  {% for metric in data %}
-    <li><a href="/plot/{{ metric.name }}">{{ metric.name }}</a></li>
-  {% endfor %}
-</ul>
+
+<div id="jstree-div">
+</div>
+
+<script>
+$(function () {
+  var tree = $('#jstree-div');
+  // Create an instance when the DOM is ready.
+  tree.jstree(
+    {
+      'core': {
+        'data' : {{ data | tojson | safe }}
+      }
+    }
+  );
+
+  // Bind events.
+  tree.on("changed.jstree", function (e, data) {
+  });
+
+  // Go to data pages if they exist, otherwise just open the tree.
+  tree.on('select_node.jstree', function(e, data) {
+    var path = "/plot/"
+
+    // jsTree puts the original data structure in a nested object
+    // called 'original'. How original of them. Hahaha I crack myself up.
+    if (data.node.original.is_link) {
+      // Take the user to the plot page.
+      href = path + data.node.id;
+      document.location.href = href;
+    } else {
+      data.instance.toggle_node(data.node);
+    };
+  });
+});
+
+</script>
 
 {% endblock %}
 

--- a/src/trendlines/templates/trendlines/layout.html
+++ b/src/trendlines/templates/trendlines/layout.html
@@ -7,8 +7,10 @@
 <!-- JavaScript -->
 <script type="text/javascript" charset="utf-8" src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
 <script type="text/javascript" charset="utf-8" src="https://cdn.plot.ly/plotly-1.43.0.min.js"></script>
+<script type="text/javascript" charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/jstree.min.js"></script>
 
 <!-- CSS -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/themes/default/style.min.css" />
 
 <title>Rename Me</title>
 

--- a/src/trendlines/templates/trendlines/layout.html
+++ b/src/trendlines/templates/trendlines/layout.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <!-- JavaScript -->
-<script type="text/javascript" charset="utf-8" src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+<script type="text/javascript" charset="utf-8" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script type="text/javascript" charset="utf-8" src="https://cdn.plot.ly/plotly-1.43.0.min.js"></script>
 <script type="text/javascript" charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.7/jstree.min.js"></script>
 

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -94,3 +94,37 @@ def adjust_jsonify_mimetype(new_type):
     current_app.config[var_name] = new_type
     yield
     current_app.config[var_name] = old
+
+
+def get_metric_parent(metric):
+    """
+    Determine the parent of a metric.
+
+    If no parent exists, the root ``#`` is given.
+
+    Parameters
+    ----------
+    metric : str
+        The dotted metric to act on.
+
+    Returns
+    -------
+    parent : str
+
+    Examples
+    --------
+    >>> get_metric_parent("foo")
+    "#"
+    >>> get_metric_parent("foo.bar")
+    "foo"
+    >>> get_metric_parent("foo.bar.baz.foo")
+    "foo.bar.baz"
+    """
+    s = metric.split(".")
+    if len(s) == 1:
+        # top-level item. parent is "#" (root)
+        parent = "#"
+    else:
+        parent = ".".join(s[:-1])
+
+    return parent

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -150,3 +150,71 @@ def format_metric_for_jstree(metric):
     """
     parent = get_metric_parent(metric)
     return {"id": metric, "parent": parent, "text": metric, "is_link": True}
+
+
+def build_jstree_data(metrics):
+    """
+    Build a list of dicts consumable by jsTree.
+
+    Fills in missing parent nodes and gives them a ``"is_link": False`` item.
+
+    Parameters
+    ----------
+    metrics : list of str
+        The metrics to display as returned by :func:`db.get_metrics`.
+
+    Returns
+    -------
+    data : list of dict
+        A JSON-serializable list of dicts. Each dict has at least ``id`` and
+        ``parent`` keys. If the metric doesn't exist (it's just a placeholder
+        parent), then the dict will have the ``"is_link": False`` item.
+
+    Notes
+    -----
+    Given the following metrics::
+
+        foo
+        foo.bar
+        bar.baz.biz
+
+    The return value of this function will be:
+
+    .. code-block:: python
+
+       # Spacing added for readability
+       # The `text` key is removed for readabiity.
+       [
+        {"id": "foo",         "parent": "#",       "is_link": True },
+        {"id": "foo.bar",     "parent": "foo",     "is_link": True },
+        {"id": "bar",         "parent": "#",       "is_link": False},
+        {"id": "bar.baz",     "parent": "bar",     "is_link": False},
+        {"id": "bar.baz.biz", "parent": "bar.baz", "is_link": True },
+       ]
+    """
+    # First go through and make all of our existing links
+    data = [format_metric_for_jstree(m) for m in metrics]
+
+    # then search through that data and find any missing parents.
+    for m in data:
+        parent = m["parent"]
+
+        # ignore root nodes and parents that already exist.
+        if parent == "#" or parent in (x['id'] for x in data):
+            continue
+
+        # Create the grandparent
+        new_parent = get_metric_parent(parent)
+
+        # Add the new, non-linked item to our data. Yes we're intentionally
+        # modifying the array we're looping over so that we make sure to
+        # get all parents no matter how deep.
+        new = {"id": m['parent'],
+               "parent": new_parent,
+               "text": m['parent'],
+               "is_link": False}
+        data.append(new)
+
+    # Lastly sort things in a predictable fashion.
+    data.sort(key=lambda d: d['id'])
+    return data

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -128,3 +128,25 @@ def get_metric_parent(metric):
         parent = ".".join(s[:-1])
 
     return parent
+
+
+def format_metric_for_jstree(metric):
+    """
+    Format a metric name into a dict consumable by jsTree.
+
+    See "Alternative JSON format" in the `jsTree docs`_.
+
+    .. _`jsTree docs`: https://www.jstree.com/docs/json/
+
+    Parameters
+    ----------
+    metric : str
+        The metric name to format.
+
+    Returns
+    -------
+    dict
+        A dict with the following keys: id, parent, text, is_link
+    """
+    parent = get_metric_parent(metric)
+    return {"id": metric, "parent": parent, "text": metric, "is_link": True}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,3 +70,15 @@ def test_adjust_jsonify_mimetype(app_context):
 ])
 def test_get_metric_parent(metric, expected):
     assert utils.get_metric_parent(metric) == expected
+
+
+@pytest.mark.parametrize("data, expected", [
+    ("foo", {"id": "foo", "parent": "#", "text": "foo", "is_link": True}),
+    ("foo.bar", {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
+                 "is_link": True}),
+    ("foo.bar.baz", {"id": "foo.bar.baz", "parent": "foo.bar",
+                     "text": "foo.bar.baz", "is_link": True}),
+])
+def test_format_metric_for_jstree(data, expected):
+    rv = utils.format_metric_for_jstree(data)
+    assert rv == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,3 +82,38 @@ def test_get_metric_parent(metric, expected):
 def test_format_metric_for_jstree(data, expected):
     rv = utils.format_metric_for_jstree(data)
     assert rv == expected
+
+
+@pytest.mark.parametrize("metrics, expected", [
+    (["foo", "foo.bar"], [
+        {"id": "foo", "parent": "#", "text": "foo", "is_link": True},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
+        ]
+     ),
+    (["foo.bar.baz"], [
+        {"id": "foo", "parent": "#", "text": "foo", "is_link": False},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
+         "is_link": False},
+        {"id": "foo.bar.baz", "parent": "foo.bar", "text": "foo.bar.baz",
+         "is_link": True},
+        ]
+     ),
+    (["foo.bar", "foo.baz"], [
+        {"id": "foo", "parent": "#", "text": "foo", "is_link": False},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
+        {"id": "foo.baz", "parent": "foo", "text": "foo.baz", "is_link": True},
+        ]
+     ),
+    (["foo", "foo.bar", "bar.baz.biz"], [
+        {"id": "bar", "parent": "#", "text": "bar", "is_link": False},
+        {"id": "bar.baz", "parent": "bar", "text": "bar.baz", "is_link": False},
+        {"id": "bar.baz.biz", "parent": "bar.baz", "text": "bar.baz.biz",
+         "is_link": True},
+        {"id": "foo", "parent": "#", "text": "foo", "is_link": True},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
+       ]
+     )
+])
+def test_build_jstree_data(metrics, expected):
+    rv = utils.build_jstree_data(metrics)
+    assert rv == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,12 @@ def test_adjust_jsonify_mimetype(app_context):
     with utils.adjust_jsonify_mimetype('foo'):
         assert current_app.config[var_name] == 'foo'
     assert current_app.config[var_name] == old
+
+
+@pytest.mark.parametrize("metric, expected", [
+    ("foo", "#"),
+    ("foo.bar", "foo"),
+    ("foo.bar.baz", "foo.bar"),
+])
+def test_get_metric_parent(metric, expected):
+    assert utils.get_metric_parent(metric) == expected


### PR DESCRIPTION
This MR adds a collapsible tree structure to the index page, powered by [`jsTree`](https://www.jstree.com/).

In order to create this tree, some helper functions were created in `utils.py`.

Looks like:
![image](https://user-images.githubusercontent.com/5386897/50859410-23296800-1348-11e9-9c56-938e7d23bd6b.png)

Closes #7.
