### PR TITLE
Test app factory

### DIFF
--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -98,7 +98,13 @@ def create_db(name):
     try:
         orm.db.connect()
     except OperationalError:
-        full_path = Path(name).resolve()
+        # .resolve() will fail for missing paths, and the `strit=False` arg
+        # wasn't added until 3.6. Since dev environment is 3.5 I need
+        # this try..except block.
+        try:        # pragma: no cover
+            full_path = Path(name).resolve()
+        except FileNotFoundError:
+            full_path = name
         logger.error("Unable to open database file '%s'" % full_path)
         raise
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+"""
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import flask
+import pytest
+from peewee import OperationalError
+
+from trendlines import app_factory
+
+
+def test_create_app(tmp_path, monkeypatch, caplog):
+    # We need to touch the file or else we'll hit the FileNotFoundError
+    path = tmp_path / "foo.cfg"
+    path.touch()
+    monkeypatch.setenv(app_factory.CFG_VAR, str(path))
+
+    rv = app_factory.create_app()
+    assert isinstance(rv, flask.app.Flask)
+    assert "Loaded config file" in caplog.text
+    assert str(path) in caplog.text
+
+
+def test_create_app_missing_user_config_file(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv(app_factory.CFG_VAR, str(tmp_path / 'foo.cfg'))
+    rv = app_factory.create_app()
+    assert isinstance(rv, flask.app.Flask)
+    assert "Failed to load config file" in caplog.text
+    assert "was not found." in caplog.text
+
+
+# XXX: Bad test: it's testing the log message from flask
+# instead something I made
+def test_create_app_missing_user_config_envvar(tmp_path, monkeypatch, caplog):
+    monkeypatch.delenv(app_factory.CFG_VAR, raising=False)
+    rv = app_factory.create_app()
+    assert isinstance(rv, flask.app.Flask)
+    assert "The environment variable" in caplog.text
+    assert "is not set and as such configuration" in caplog.text
+
+
+def test_create_db(tmp_path):
+    path = tmp_path / "foo.db"
+    app_factory.create_db(str(path))
+    # if the function worked the file should now exist.
+    assert path.exists()
+
+
+@patch("flask.Config.from_envvar",
+       MagicMock(side_effect=Exception("foobar"))
+)
+def test_create_app_user_config_general_exception(caplog):
+    rv = app_factory.create_app()
+    assert isinstance(rv, flask.app.Flask)
+    assert "An unknown error occured while reading from the" in caplog.text
+    assert "foobar" in caplog.text
+
+
+@patch("trendlines.orm.db.connect", MagicMock(side_effect=OperationalError))
+def test_create_db_logs_and_raises_operational_error(caplog):
+    with pytest.raises(OperationalError):
+        app_factory.create_db("foo")
+
+    assert "Unable to open database file" in caplog.text
+    assert "foo" in caplog.text


### PR DESCRIPTION
This adds tests for `app_factory.py`.

This ended up being needed because I was finding that I didn't know exactly how things behaved when

1. the user config file was missing
2. the user config var was not set
3. the path to the DB file was missing or not writable, or
4. other things.