### PR TITLE
Switch x axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
++ Implemented switching between sequential and time-series data. (#8).
 
 
 ## v0.1.1 (2019-01-10):

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -131,9 +131,9 @@ def format_data(data):
     Returns
     -------
     data : dict
-        Dictionary of data where ``timestamp`` is a POSIX integer timestamp.
+        Dictionary of data where ``timestamp`` is an ISO 8601 string.
     """
-    data = [{'timestamp': row.timestamp.timestamp(),
+    data = [{'timestamp': row.timestamp.isoformat(),
              'value': row.value,
              'id': row.datapoint_id,
              'n': n}

--- a/src/trendlines/templates/trendlines/plot.html
+++ b/src/trendlines/templates/trendlines/plot.html
@@ -35,6 +35,24 @@
   trace = [ trace1 ];
   Plotly.plot(TESTER, trace);
 
+  $(document).ready(
+    function() {
+      $(":radio[name='x-axis-type']").change(
+        function() {
+          // Determine which x scale to use.
+          if (this.value == "time") {
+            new_x = x;
+          } else if (this.value == "sequential") {
+            new_x = n;
+          }
+
+          // Adjust the x values of the data.
+          Plotly.restyle(TESTER, 'x', [new_x]);
+        }
+      )
+    }
+  );
+
 </script>
 
 {% endblock %}

--- a/src/trendlines/templates/trendlines/plot.html
+++ b/src/trendlines/templates/trendlines/plot.html
@@ -3,6 +3,16 @@
 {% block body %}
 
 <h1>{{ name }}</h1>
+
+<div id="change-axis-buttons" class="btn-group btn-group-toggle" data-toggle="buttons">
+  <label class="btn btn-primary active">
+    <input id="x-axis-type-sequential" type="radio" name="x-axis-type" autocomplete="off" value="sequential" checked>Sequential
+  </label>
+  <label class="btn btn-primary">
+    <input id="x-axis-type-time" type="radio" name="x-axis-type" autocomplete="off" value="time">Time Series
+  </label>
+</div>
+
 <div id="graph" style="width:90%; height:500px;"></div>
 
 <script>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 """
+from datetime import datetime
 
 import pytest
 
@@ -93,3 +94,9 @@ def test_format_data(raw_data):
     assert "id" in data_0.keys()
     assert "n" in data_0.keys()
     assert data_0['value'] == 15
+    assert isinstance(data_0['timestamp'], str)
+    try:
+        #  datetime.fromisoformat(data_0['timestamp'])   # Python 3.7 only
+        datetime.strptime(data_0['timestamp'], "%Y-%m-%dT%H:%M:%S")
+    except Exception as err:
+        pytest.fail("data['timestamp'] is not the correct format")


### PR DESCRIPTION
This MR adds the capability to switch between sequential data (`x=1, 2, 3, ...`) and time-series data.

It also updates tests a bit since I found that making a breaking change to the code did not break tests, so that had to be fixed.

Closes #8.