### PR TITLE
Api change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 ## Unreleased
++ [BREAKING] Updated REST API: "add" and "get" changed to "data". The HTTP
+  method will be used to determine adding or retrieving.
 + Implemented switching between sequential and time-series data. (#8).
 
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To send in data using the HTTP POST method:
 curl --data '{"metric": "foo.bar", "value": 52.88, "time": '${date +%s}'}' \
      --header "Content-Type: application/json" \
      --request POST \
-     http://$SERVER/api/v1/add`
+     http://$SERVER/api/v1/data`
 ```
 
 Or via UDP:
@@ -154,5 +154,5 @@ metric shows you the graph of historical data.
 You can also export the data as JSON by sending an HTTP GET request:
 
 ```
-curl http://$SERVER/api/v1/get/$METRIC_NAME
+curl http://$SERVER/api/v1/data/$METRIC_NAME
 ```

--- a/add_data.sh
+++ b/add_data.sh
@@ -3,17 +3,18 @@
 PORT=5000
 URL="http://localhost:$PORT"
 API="$URL/api/v1/data"
+C_TYPE="Content-Type: application/json"
 
 for run in {1..10}
 do
-curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$API";
+curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`'}' -H "$C_TYPE" -X POST "$API";
 sleep 0.1;
 done;
 sleep 1;
-curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`', "time":'`date +%s`'}' -H "Content-Type: application/json" -X POST "$API";
+curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`', "time":'`date +%s`'}' -H "$C_TYPE" -X POST "$API";
 
 for run in {1..5}
 do
-curl -d '{"metric":"baz", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$API";
+curl -d '{"metric":"baz", "value":'`shuf -i 1-100 -n 1`'}' -H "$C_TYPE" -X POST "$API";
 sleep 0.3;
 done;

--- a/add_data.sh
+++ b/add_data.sh
@@ -1,18 +1,19 @@
 #! /bin/bash
 
 PORT=5000
-URL="http://localhost:$PORT/api/v1"
+URL="http://localhost:$PORT"
+API="$URL/api/v1/data"
 
 for run in {1..10}
 do
-curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$URL"/add;
+curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$API";
 sleep 0.1;
 done;
 sleep 1;
-curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`', "time":'`date +%s`'}' -H "Content-Type: application/json" -X POST "$URL"/add;
+curl -d '{"metric":"foo.bar", "value":'`shuf -i 1-100 -n 1`', "time":'`date +%s`'}' -H "Content-Type: application/json" -X POST "$API";
 
 for run in {1..5}
 do
-curl -d '{"metric":"baz", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$URL"/add;
+curl -d '{"metric":"baz", "value":'`shuf -i 1-100 -n 1`'}' -H "Content-Type: application/json" -X POST "$API";
 sleep 0.3;
 done;

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -51,8 +51,8 @@ def plot(metric=None):
     return render_template('trendlines/plot.html', name=metric, data=data)
 
 
-@api.route("/api/v1/add", methods=['POST'])
-def add():
+@api.route("/api/v1/data", methods=['POST'])
+def post_datapoint():
     """
     Add a new value and possibly a metric if needed.
 

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -82,7 +82,7 @@ def post_datapoint():
 
 
 @api.route("/api/v1/<metric>", methods=["GET"])
-@api.route("/api/v1/get/<metric>", methods=["GET"])
+@api.route("/api/v1/data/<metric>", methods=["GET"])
 def get_data_as_json(metric):
     """
     Return data for a given metric as JSON.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -49,7 +49,7 @@ def test_api_add_with_missing_key(client):
 
 
 def test_api_get_data_as_json(client, populated_db):
-    rv = client.get("/api/v1/get/foo")
+    rv = client.get("/api/v1/data/foo")
     assert rv.status_code == 200
     assert rv.is_json
     d = rv.get_json()['rows']
@@ -59,7 +59,7 @@ def test_api_get_data_as_json(client, populated_db):
 
 
 def test_api_get_data_as_json_metric_not_found(client):
-    rv = client.get("/api/v1/get/missing")
+    rv = client.get("/api/v1/data/missing")
     assert rv.status_code == 404
     assert rv.is_json
     d = rv.get_json()
@@ -69,7 +69,7 @@ def test_api_get_data_as_json_metric_not_found(client):
 
 
 def test_api_get_data_as_json_no_data_for_metric(client, populated_db):
-    rv = client.get("/api/v1/get/empty_metric")
+    rv = client.get("/api/v1/data/empty_metric")
     assert rv.status_code == 404
     assert rv.is_json
     d = rv.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -36,14 +36,14 @@ def test_plot_with_data(client, populated_db):
 
 def test_api_add(client):
     data = {"metric": "test", "value": 10}
-    rv = client.post("/api/v1/add", json=data)
+    rv = client.post("/api/v1/data", json=data)
     assert rv.status_code == 201
     assert b"Added DataPoint to Metric" in rv.data
 
 
 def test_api_add_with_missing_key(client):
     data = {"value": 10}
-    rv = client.post("/api/v1/add", json=data)
+    rv = client.post("/api/v1/data", json=data)
     assert rv.status_code == 400
     assert b"Missing required key. Required keys are:" in rv.data
 


### PR DESCRIPTION
This changes the API: `get` and `add` are no longer used and are instead replaced with `data`. This will make it so that I can eventually implement #29.

```
# old
GET /api/v1/get/<metric_name>
POST /api/v1/add   {json_data}

# new
GET /api/v1/data/<metric_name>    # to get data for a specific metric
POST /api/v1/data   {json_data}
```

Also a cleanup of `add_data.sh` even though that's kinda out of scope of this MR. Oops.