### PR TITLE
Better url prefix injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ## Unreleased
 + Removed a confusing route: `/api/v1/<metric>`. (#39)
-+ Added a title that will link back to the index page.
++ Added a title that will link back to the index page. (#40)
++ Changed the way we handle generating links when behind a proxy that's
+  mucking about with the URLs. (#41)
 + Units will now be displayed on the y-axis if they exist. (#37)
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,38 @@ ports:
 ```
 
 
+### Running behind a proxy
+
+A typical case, for me at least, is adding this application to a server that's
+already running Apache for other things. In this case, make the following
+adjustments:
+
+1.  Add a proxy to the `VirtualHost` in your apache config.
+2.  Make sure to set the `URL_PREFIX` variable in your Trendlines config file.
+
+```apache
+# /etc/apache2/sites-enabled/your-site.conf
+<VirtualHost *:80>
+...
+    # optionally replace all instances of "trendlines" with whatever you want
+    # Make sure the port on ProxyPass and ProxyPassReverse matches what is
+    # exposed in your docker-compose.yml file.
+    <Location /trendlines>
+        ProxyPreserveHost On
+        ProxyPass http://0.0.0.0:5082/trendlines
+        ProxyPassReverse http://0.0.0.0:5082/trendlines
+
+        RequestHeader set X-Forwarded-Port 80
+    </Location>
+</VirtualHost>
+```
+
+```python
+# /var/www/trendlines/trendlines.cfg
+URL_PREFIX = "/trendlines"    # Whatever you put in your Apache proxy
+```
+
+
 ## Usage
 
 TODO.

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -40,8 +40,9 @@ def create_app():
 
 
     logger.debug("Registering blueprints.")
-    app.register_blueprint(routes.pages)
-    app.register_blueprint(routes.api)
+    url_prefix = app.config.get("URL_PREFIX", None)
+    app.register_blueprint(routes.pages, url_prefix=url_prefix)
+    app.register_blueprint(routes.api, url_prefix=url_prefix)
 
     # Create the database file and populate initial tables if needed.
     create_db(app.config['DATABASE'])

--- a/src/trendlines/default_config.py
+++ b/src/trendlines/default_config.py
@@ -16,6 +16,10 @@ DB_TYPE = "sqlite"
 # The database file to use. Ignored if DB_TYPE is not "sqlite"
 DATABASE = "./internal.db"
 
+# Set this value to insert a prefix into any generaged URLs. Mainly used when
+# running behind a proxy that is adjusting URLs.
+#URL_PREFIX = "/trendlines"
+
 # Flask Builtins ################################
 DEBUG = False
 TESTING = False

--- a/src/trendlines/templates/trendlines/index.html
+++ b/src/trendlines/templates/trendlines/index.html
@@ -30,32 +30,8 @@ $(function () {
     // jsTree puts the original data structure in a nested object
     // called 'original'. How original of them. Hahaha I crack myself up.
     if (data.node.original.is_link) {
-      // Handle cases where an external force is modifying the URL provided
-      // to the client. For example, when Apache sets:
-      //   <Location /extra/stuff>
-      // We can't do this server-side because the trendlines server doesn't
-      // know that it's being routed through an Apache server.
-      // Basically we're doing this:
-      //    http://server.com/extra/stuff                  // current
-      //  - http://server.com                              // origin
-      //    ----------------------------------------------
-      //  =                  /extra/stuff                  // extra
-      //  +                              /plot/metric.name // expected
-      //  + http://server.com                              // location.origin
-      //    ----------------------------------------------
-      //  = http://server.com/extra/stuff/plot/metric.name // new_href
-
       var expected = path.replace("PLACEHOLDER", data.node.id);
-      var current = document.location.href;
-      var origin = document.location.origin;
-      var extra = current.replace(origin, "");
-      // For the case where our path is *not* being modified (eg:
-      // `<Location />` in apache), `current` has a trailing slash, causing
-      // `extra` to simply be "/". We remove that so our `new_href` doesn't
-      // have double slashes: "http://server.com//plot/metric_name".
-      if (extra == "/") { extra = ""; }
-
-      var new_href = origin + extra + expected;
+      var new_href = document.location.origin + expected;
 
       // Take the user to the plot page.
       document.location.href = new_href;


### PR DESCRIPTION
Remove a lot of the client-side URL generation stuff. Move to using a config file setting `URL_PREFIX`.

Add docs with an example one might use `URL_PREFIX`.