### PR TITLE
Remove the confusing /api/v1/<metric> route.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
++ Removed a confusing route: `/api/v1/<metric>`. (#39)
 + Added a title that will link back to the index page.
 
 

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -81,7 +81,6 @@ def post_datapoint():
     return msg, 201
 
 
-@api.route("/api/v1/<metric>", methods=["GET"])
 @api.route("/api/v1/data/<metric>", methods=["GET"])
 def get_data_as_json(metric):
     """


### PR DESCRIPTION
Remove the confusing `/api/v1/<metric>` route.

Fixes #39.