### PR TITLE
[WIP] Ajax testing with capybara

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov==2.6.0
 freezegun==0.3.11
 coveralls==1.5.1
 wheel==0.32.3
+capybara-py==0.1.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Global PyTest fixtures.
 """
 from pathlib import Path
 
+import capybara
 import pytest
 
 from trendlines import db
@@ -11,6 +12,8 @@ from trendlines.app_factory import create_app
 from trendlines.app_factory import create_db
 from trendlines.orm import DataPoint
 from trendlines.orm import Metric
+
+pytest_plugins = ["capybara.pytest_plugin"]
 
 
 @pytest.fixture
@@ -30,6 +33,8 @@ def app():
         pass
 
     app = create_app()
+    capybara.app = app
+    capybara.default_max_wait_time = 5
 
     # Since the `create_db` function modifies orm.db directly, we can simply
     # call it here. I guess *technically* what's happening is whatever

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,6 +12,12 @@ def test_index(client):
 
 
 @pytest.mark.xfail(reason="Need to figure out the AJAX testing.")
+def test_index_with_data_(app, page, populated_db):
+    page.visit("/")
+    assert page.has_text("empty_metric")
+
+
+@pytest.mark.xfail(reason="Need to figure out the AJAX testing.")
 def test_index_with_data(client, populated_db):
     rv = client.get('/')
     assert rv.status_code == 200


### PR DESCRIPTION
This is an attempt to add testing for the AJAX calls (#46) via the [`capybara-py`](https://elliterate.github.io/capybara.py/) package.