### PR TITLE
Celery workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ URL_PREFIX = "/trendlines"    # Whatever you put in your Apache proxy
 ```
 
 
+### Running with Celery
+
+Add the following services to your `docker-compose.yml`:
+
+```yaml
+redis:
+  image: redis
+  ports:
+    - "6379:6379"
+celery:
+  image: dougthor42/trendlines:latest
+  ports:
+    - "9999:9999"
+  volumes:
+    # should be the same as what's in the 'trendlines' service
+    - type: bind
+      source: /var/www/trendlines
+      target: /data
+  command: celery worker -l info -A trendlines.celery_app.celery
+```
+
+
 ## Usage
 
 TODO.

--- a/docker-build.yml
+++ b/docker-build.yml
@@ -1,0 +1,44 @@
+#
+# Docker-compose file used when building and running locally (WSL)
+#
+
+# Need version >= 3.2 because of how we define our volumes
+version: "3.2"
+services:
+  trendlines:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    restart: always
+    ports:
+      - 5000:80
+    volumes:
+      - type: bind
+        # Host location. This can be anywhere on your file system.
+        source: c:/gitlab/github/trendlines/config
+        # Within the container. The /data directory holds both the internal
+        # database file (if you're using SQLite) and the configuration file
+        # `trendlines.cfg`.
+        target: /data
+      - type: bind
+        source: c:/gitlab/github/trendlines/internal.db
+        target: /data/internal.db
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+  celery:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "9999:9999"
+    volumes:
+      - type: bind
+        # Host location. This can be anywhere on your file system.
+        source: c:/gitlab/github/trendlines/config
+        # Within the container. The /data directory holds both the internal
+        # database file (if you're using SQLite) and the configuration file
+        # `trendlines.cfg`.
+        target: /data
+    command: celery worker -l info -A trendlines.celery_app.celery

--- a/docker-build.yml
+++ b/docker-build.yml
@@ -13,13 +13,13 @@ services:
     ports:
       - 5000:80
     volumes:
-      - type: bind
+      # - type: bind
         # Host location. This can be anywhere on your file system.
-        source: c:/gitlab/github/trendlines/config
+        # source: c:/gitlab/github/trendlines/config
         # Within the container. The /data directory holds both the internal
         # database file (if you're using SQLite) and the configuration file
         # `trendlines.cfg`.
-        target: /data
+        # target: /data
       - type: bind
         source: c:/gitlab/github/trendlines/internal.db
         target: /data/internal.db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,7 @@
+#
+# Example docker-compose.yml file for running on a linux server.
+#
+
 # Need version >= 3.2 because of how we define our volumes
 version: "3.2"
 services:
@@ -5,7 +9,7 @@ services:
     image: dougthor42/trendlines:latest
     restart: always
     ports:
-      - 80:80
+      - "127.0.0.1:80:80"
     volumes:
       - type: bind
         # Host location. This can be anywhere on your file system.
@@ -14,3 +18,17 @@ services:
         # database file (if you're using SQLite) and the configuration file
         # `trendlines.cfg`.
         target: /data
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+  celery:
+    image: dougthor42/trendlines:latest
+    ports:
+      - "9999:9999"
+    volumes:
+      # This should be the same as what's in the 'trendlines' service.
+      - type: bind
+        source: /var/www/trendlines
+        target: /data
+    command: celery worker -l info -A trendlines.celery_app.celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask==1.0.2
 peewee==3.8.0
+requests==2.21.0
+celery[redis]==4.2.1

--- a/runworker.py
+++ b/runworker.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Run a celery worker.
+"""
+import os
+from pathlib import Path
+
+from celery.bin import worker
+
+from trendlines.celery_factory import create_celery
+
+# Load our configuration. We're using pathlib and `.resolve()` because
+# Flask's working dir is src/trendlines and uses that when running
+# `app.config.from_envvar`, so the path it attemps to load is
+# `/proj_folder/src/trendlines/config/localhost.cfg` if `cfg_file` is not
+# absolute.
+cfg_file = Path('./config/localhost.cfg')
+os.environ['TRENDLINES_CONFIG_FILE'] = str(cfg_file.resolve())
+
+#  app.worker_main()
+celery = create_celery()
+worker = worker.worker(app=celery)
+worker.run()

--- a/src/trendlines/celery_app.py
+++ b/src/trendlines/celery_app.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+Create the celery application.
+
+Only used because I have to set the TRENDLINES_CONFIG_FILE environment
+variable and I haven't bothered to figure out a better way.
+"""
+import os
+
+from trendlines.celery_factory import create_celery
+
+os.environ['TRENDLINES_CONFIG_FILE'] = "/data/trendlines.cfg"
+celery = create_celery()

--- a/src/trendlines/celery_factory.py
+++ b/src/trendlines/celery_factory.py
@@ -120,13 +120,6 @@ def create_celery():
     celery.finalize()
     logger.debug("Celery has been finalized.")
 
-    class UDPHandler(socketserver.BaseRequestHandler):
-        def handle(self):
-            data = self.request[0].strip()
-            parsed = utils.parse_socket_data(data)
-            logger.debug("UDP: {}".format(parsed))
-            r = requests.post(URL, json=parsed)
-            logger.info(r.status_code)
 
     class TCPHandler(socketserver.BaseRequestHandler):
         def handle(self):
@@ -146,13 +139,6 @@ def create_celery():
             self.request.sendall(b"accepted")
 
     @celery.task
-    def listen_to_udp():
-        hp = (HOST, UDP_PORT)
-        logger.info("listening for UDP on %s:%s" % hp)
-        with socketserver.UDPServer(hp, UDPHandler) as server:
-            server.serve_forever()
-
-    @celery.task
     def listen_to_tcp():
         hp = (HOST, TCP_PORT)
         logger.info("listening for TCP on %s:%s" % hp)
@@ -161,7 +147,7 @@ def create_celery():
 
     # Start our tasks
     logger.debug("Starting tasks")
-    listen_to_udp.delay()
+    #  listen_to_udp.delay()
     listen_to_tcp.delay()
 
     return celery

--- a/src/trendlines/celery_factory.py
+++ b/src/trendlines/celery_factory.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""
+Celery factory and related functions.
+"""
+import errno
+import os
+import socketserver
+import types
+from pathlib import Path
+from traceback import format_exc
+
+import requests
+from celery import Celery
+from celery.exceptions import ImproperlyConfigured
+
+from trendlines import utils
+from trendlines import logger
+
+# TODO: queueing?
+
+CFG_VAR = "TRENDLINES_CONFIG_FILE"
+
+
+def config_from_envvar(app, var_name, silent=False):
+    """
+    Load celery config from an envvar that points to a python config file.
+
+    Basically this:
+
+        config_from_pyfile(os.environ['YOUR_APP_SETTINGS'])
+
+    Example:
+        >>> os.environ['CELERY_CONFIG_MODULE'] = './some_dir/config_file.cfg'
+        >>> config_from_envvar(celery, 'CELERY_CONFIG_MODULE')
+
+    Arguments:
+        app (Celery app instance): The celery app to update
+        var_name (str): The env var to use.
+        silent (bool): If true then import errors will be ignored.
+
+    Shamelessly taken from Flask. Like, almost exactly. Thanks!
+    https://github.com/pallets/flask/blob/74691fbe0192de1134c93e9821d5f8ef65405670/flask/config.py#L88
+    """
+    rv = os.environ.get(var_name)
+    if not rv:
+        if silent:
+            return False
+        raise RuntimeError('The environment variable %r is not set'
+                           ' and as such configuration could not be'
+                           ' loaded. Set this variable to make it'
+                           ' point to a configuration file.' % var_name)
+    return config_from_pyfile(app, rv, silent=silent)
+
+
+def config_from_pyfile(app, filename, silent=False):
+    """
+    Mimics Flask's config.from_pyfile()
+
+    Allows loading a separate, perhaps non `.py`, file into Celery.
+
+    Example:
+        >>> config_from_pyfile(celery, './some_dir/config_file.cfg')
+
+    Arguments:
+        app (Celery app instance): The celery app to update
+        filename (str): The file to load.
+        silent (bool): If true then import errors will be ignored.
+
+    Also shamelessly taken from Flask:
+    https://github.com/pallets/flask/blob/74691fbe0192de1134c93e9821d5f8ef65405670/flask/config.py#L111
+    """
+    filename = str(Path(filename).resolve())
+    d = types.ModuleType('config')
+    d.__file__ = filename
+
+    try:
+        with open(filename, 'rb') as config_file:
+            exec(compile(config_file.read(), filename, 'exec'), d.__dict__)
+    except IOError as e:
+        if silent and e.errno in(errno.ENOENT, errno.EISDIR, errno.ENOTDIR):
+            return False
+        e.strerror = "Unable to load config file (%s)" % e.strerror
+        raise
+
+    # Remove any hidden attributes: __ and _
+    for k in list(d.__dict__.keys()):
+        if k.startswith("_"):
+            del d.__dict__[k]
+
+    logger.debug("Config values: %s" % d.__dict__)
+    app.conf.update(d.__dict__)
+    return True
+
+
+def create_celery():
+    celery = Celery(__name__, autofinalize=False)
+
+    # Pull config from file. This is basically the same as what is
+    # done in app_factory.create_app()
+    celery.config_from_object('trendlines.default_config')
+    try:
+        config_from_envvar(celery, CFG_VAR)
+        logger.info("Loaded config file '%s'" % os.environ[CFG_VAR])
+    except FileNotFoundError:
+        msg = "Failed to load config file. The file %s='%s' was not found."
+        logger.warning(msg % (CFG_VAR, os.environ[CFG_VAR]))
+    except (RuntimeError, ImproperlyConfigured) as err:
+        # Celery's error for missing env var is sufficient.
+        logger.warning(str(err))
+    except Exception as err:
+        logger.warning("An unknown error occured while reading from the"
+                       " config file. See debug stack trace for details.")
+        logger.debug(format_exc())
+
+
+    UDP_PORT = celery.conf['UDP_PORT']
+    TCP_PORT = celery.conf['TCP_PORT']
+    HOST = celery.conf['TARGET_HOST']
+    URL = celery.conf['TRENDLINES_API_URL']
+    celery.finalize()
+    logger.debug("Celery has been finalized.")
+
+    class UDPHandler(socketserver.BaseRequestHandler):
+        def handle(self):
+            data = self.request[0].strip()
+            parsed = utils.parse_socket_data(data)
+            logger.debug("UDP: {}".format(parsed))
+            r = requests.post(URL, json=parsed)
+            logger.info(r.status_code)
+
+    class TCPHandler(socketserver.BaseRequestHandler):
+        def handle(self):
+            data = self.request.recv(1024).strip()
+            try:
+                parsed = utils.parse_socket_data(data)
+                logger.debug("TCP: {}".format(parsed))
+            except ValueError:
+                logger.warn("TCP: Failed to parse `%s`." % data)
+                return
+
+            try:
+                r = requests.post(URL, json=parsed)
+                logger.info(r.status_code)
+            except Exception:
+                raise
+            self.request.sendall(b"accepted")
+
+    @celery.task
+    def listen_to_udp():
+        hp = (HOST, UDP_PORT)
+        logger.info("listening for UDP on %s:%s" % hp)
+        with socketserver.UDPServer(hp, UDPHandler) as server:
+            server.serve_forever()
+
+    @celery.task
+    def listen_to_tcp():
+        hp = (HOST, TCP_PORT)
+        logger.info("listening for TCP on %s:%s" % hp)
+        with socketserver.TCPServer(hp, TCPHandler) as server:
+            server.serve_forever()
+
+    # Start our tasks
+    logger.debug("Starting tasks")
+    listen_to_udp.delay()
+    listen_to_tcp.delay()
+
+    return celery

--- a/src/trendlines/default_config.py
+++ b/src/trendlines/default_config.py
@@ -20,6 +20,16 @@ DATABASE = "./internal.db"
 # running behind a proxy that is adjusting URLs.
 #URL_PREFIX = "/trendlines"
 
+# Celery stuff. See here for names:
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html
+broker_url = "redis://redis"
+
+# Socket stuff.
+TARGET_HOST = "0.0.0.0"
+TRENDLINES_API_URL = "http://trendlines/api/v1/data"
+TCP_PORT = 9999
+UDP_PORT = 9999
+
 # Flask Builtins ################################
 DEBUG = False
 TESTING = False


### PR DESCRIPTION
This adds a celery workers and support for sending in data via TCP and UDP.

Fixes #6.

+ Updated `README.md` with info about running with celery in a docker stack.
+ Added `docker_build.yml` for building/running the stack locally
+ Updated the example `docker-compose.yml` file for celery/redis.
+ Added `celery[redis]` and `requests` to `requirements.txt`
+ Added a `runworker.py` script
+ Updated `default_config.py` to include Celery stuff and to be suitable for docker-compose deployment
+ Of course all the celery stuff.

WIP because:

+ [x] Tests are broken. The change to `DATABASE` in `default_config.py` borked things up.
+ [x] Only TCP is currently working. For some reason, when I deploy to my test server it's random which handler actually activates (TCP or UDP). So for now I've removed the UDP handler.
+ [x] There's little to no error handling in the handlers.
+ [x] If a timestamp isn't given, I need to make sure I set it in the *handler* and not when the REST api is actually called. This is because there could be a queue of socket data and the REST api can't handle it as fast.
+ [ ] Speaking of queues... do I need to implement my own Queue al-la [this answer](https://stackoverflow.com/a/26288902/1354930)?