### PR TITLE
Use peewee-moves for database migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
++ Implemented database migrations (#62)
 + Changed (again) how we handle being behind a proxy. (#60)
 
 

--- a/migrations/0001_create_table_metric.py
+++ b/migrations/0001_create_table_metric.py
@@ -1,0 +1,15 @@
+"""
+create table metric
+date created: 2019-02-14 22:01:44.111130
+"""
+
+
+def upgrade(migrator):
+    with migrator.create_table('metric') as table:
+        table.int('metric_id')
+        table.char('name', max_length=120)
+        table.char('units', max_length=24, null=True)
+
+
+def downgrade(migrator):
+    migrator.drop_table('metric')

--- a/migrations/0002_create_table_datapoint.py
+++ b/migrations/0002_create_table_datapoint.py
@@ -1,0 +1,16 @@
+"""
+create table datapoint
+date created: 2019-02-14 22:01:50.586924
+"""
+
+
+def upgrade(migrator):
+    with migrator.create_table('datapoint') as table:
+        table.int('datapoint_id')
+        table.foreign_key('INT', 'metric_id', on_delete=None, on_update=None, references='metric.metric_id')
+        table.float('value')
+        table.int('timestamp')
+
+
+def downgrade(migrator):
+    migrator.drop_table('datapoint')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==1.0.2
 peewee==3.8.0
 requests==2.21.0
 celery[redis]==4.2.1
+peewee-moves==2.0.0

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -20,7 +20,12 @@ DB_OPTS = {
 db = SqliteDatabase(None)
 
 
-class DataModel(Model):
+class BaseModel(Model):
+    class Meta(object):
+        database = db
+
+
+class DataModel(BaseModel):
     """
     Model for storing data points.
 
@@ -28,19 +33,17 @@ class DataModel(Model):
     a point in the future where I want to switch to one-file-per-metric
     and having a separate DataModel class will make this easier.
     """
-    class Meta(object):
-        database = db
+    pass
 
 
-class InternalModel(Model):
+class InternalModel(BaseModel):
     """
     Model for internal data tables.
 
     *IF* we were to move to one-file-per-metric, then this model would
     hold all of the non-dynamically-generated tables.
     """
-    class Meta(object):
-        database = db
+    pass
 
 
 class Metric(InternalModel):


### PR DESCRIPTION
I plan on making changes to the database schema in the future, and we need to have migrations in place to support those changes.

I've chosen [`peewee-moves`](https://github.com/timster/peewee-moves) as our migration tool, winning out over [`peewee-migrate`](https://github.com/klen/peewee_migrate) (and [`peewee-db-evolve`](https://github.com/keredson/peewee-db-evolve), but I think that might actually solve a different problem...`)

Why did I choose `peewee-moves`? At the time of this writing, the documentation for `peewee-moves` was better and I was actually able to get it to work. That said, `peewee-migrate` appears to be more popular (by GitHub star count).