### PR TITLE
Spec limits database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 + Implemented database migrations (#62)
 + Changed (again) how we handle being behind a proxy. (#60)
++ Added columns to the `Metric` table to support limits. (#65)
 
 
 ## v0.3.0 (2019-01-28)

--- a/migrations/0003_add_spec_limits.py
+++ b/migrations/0003_add_spec_limits.py
@@ -1,0 +1,14 @@
+"""
+add_spec_limits
+date created: 2019-02-14 23:30:21.963046
+"""
+
+
+def upgrade(migrator):
+    migrator.add_column('metric', 'upper_limit', 'float', null=True)
+    migrator.add_column('metric', 'lower_limit', 'float', null=True)
+
+
+def downgrade(migrator):
+    migrator.drop_column('metric', 'lower_limit')
+    migrator.drop_column('metric', 'upper_limit')

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -54,6 +54,8 @@ class Metric(InternalModel):
     metric_id = IntegerField(primary_key=True)
     name = CharField(max_length=120)
     units = CharField(max_length=24, null=True)
+    upper_limit = FloatField(null=True)
+    lower_limit = FloatField(null=True)
 
     def __repr__(self):
         s = "<Metric: {id}, {name}, units={units}>"


### PR DESCRIPTION
This PR updates the `Metric` table to support limits by adding two columns: `lower_limit` and `upper_limit`.

Required for #12.