### PR TITLE
Unique metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 + Added columns to the `Metric` table to support limits. (#65)
 + DB migrations are now inlcuded in the docker image, and documentation
   was added on how to perform upgrades. (#67)
++ The `Metric.name` column is now forced to be unique. Previously this was
+  enforced on the software side, but not on the database side. (#66)
 
 
 ## v0.3.0 (2019-01-28)

--- a/migrations/0004_unique_constraint_metric_name.py
+++ b/migrations/0004_unique_constraint_metric_name.py
@@ -1,0 +1,12 @@
+"""
+unique_constraint_metric.name
+date created: 2019-02-18 16:23:33.621724
+"""
+
+
+def upgrade(migrator):
+    migrator.add_index("metric", ["name"], unique=True)
+
+
+def downgrade(migrator):
+    migrator.drop_index("metric", ["name"])

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -52,7 +52,7 @@ class Metric(InternalModel):
     """
 
     metric_id = IntegerField(primary_key=True)
-    name = CharField(max_length=120)
+    name = CharField(max_length=120, unique=True)
     units = CharField(max_length=24, null=True)
     upper_limit = FloatField(null=True)
     lower_limit = FloatField(null=True)


### PR DESCRIPTION
Make sure the `Metric.name` column is unique on the database side of things.

Fixes #66.

This was not really an issue because the API would ensure uniqueness (by first querying for the `name` in the table) but if anyone tried to modify the database directly then things could get messed up. Now that can't happen anymore (unless they're modifying tables, but that's not something I can control).