### PR TITLE
Metric api delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 + The `Metric.name` column is now forced to be unique. Previously this was
   enforced on the software side, but not on the database side. (#66)
 + The `DataPoint.metric_id` foreign key is now set to CASCADE on deletes (#69)
-+ `GET /api/v1/metric/<metric_name` has been implemented (#73)
++ `GET /api/v1/metric/<metric_name>` has been implemented (#73)
++ `DELETE /api/v1/metric/<metric_name>` has been implemented (#78)
 
 
 ## v0.3.0 (2019-01-28)

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -144,3 +144,25 @@ def get_metric_as_json(metric):
     data = utils.format_metric_api_result(raw_data)
 
     return jsonify(data)
+
+
+@api.route("/api/v1/metric/<metric>", methods=["DELETE"])
+def delete_metric(metric):
+    logger.debug("'api: DELETE '%s'" % metric)
+
+    try:
+        found = db.Metric.get(db.Metric.name == metric)
+        found.delete_instance()
+    except DoesNotExist:
+        http_status = 404
+        detail = "The metric '{}' does not exist".format(metric)
+        resp = utils.Rfc7807ErrorResponse(
+            type_="metric-not-found",
+            title="Metric not found",
+            status=http_status,
+            detail=detail,
+        )
+        logger.warning("API error: %s" % detail)
+        return resp.as_response(), http_status
+    else:
+        return "", 204

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -96,3 +96,24 @@ def test_api_get_metric_as_json_not_found(client, populated_db, caplog):
     assert metric in d['detail']
     assert d['title'] == "Metric not found"
     assert "API error:" in caplog.text
+
+
+def test_api_delete_metric(client, populated_db):
+    metric = "foo.bar"
+    rv = client.delete("/api/v1/metric/{}".format(metric))
+    assert rv.status_code == 204
+
+    # Verify it's actually been deleted
+    after = client.get("/api/v1/metric/{}".format(metric))
+    assert after.status_code == 404
+
+
+def test_api_delete_metric_not_found(client, populated_db, caplog):
+    metric = "missing"
+    rv = client.delete("/api/v1/metric/{}".format(metric))
+    assert rv.status_code == 404
+    assert rv.is_json
+    d = rv.get_json()
+    assert metric in d['detail']
+    assert d['title'] == "Metric not found"
+    assert "API error:" in caplog.text


### PR DESCRIPTION
This adds a "DELETE" api for metrics.

```
DELETE /api/v1/metric/<metric_name>
```

Part of #57.