### PR TITLE
Metric api post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 + The `DataPoint.metric_id` foreign key is now set to CASCADE on deletes (#69)
 + `GET /api/v1/metric/<metric_name>` has been implemented (#73)
 + `DELETE /api/v1/metric/<metric_name>` has been implemented (#78)
++ `POST /api/v1/metric` has been implemented (#74)
 
 
 ## v0.3.0 (2019-01-28)

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -148,6 +148,27 @@ def get_metric_as_json(metric):
 
 @api.route("/api/v1/metric", methods=["POST"])
 def post_metric():
+    """
+    Create a new metric.
+
+    Accepts JSON data with the following format:
+
+    .. code-block::json
+       {
+         "name": "your.metric_name.here",
+         "units": string, optional,
+         "upper_limit": {float, optional},
+         "lower_limit": {float, optional},
+       }
+
+    Returns ``201`` on success, ``400`` on malformed JSON data (such as when
+    ``name`` is missing), or ``409`` if the metric already exists.
+
+    See Also
+    --------
+    :func:`routes.get_metric_as_json`
+    :func:`routes.delete_metric`
+    """
     data = request.get_json()
 
     try:


### PR DESCRIPTION
This adds a `POST` api for adding metrics. Right now it only supports JSON data - I may add support for URL params in the future.

The expected JSON data is of the same form as the data returned by a GET request. So in theory, you could do something like this:

```
metric_json = GET /api/v1/metric/some_metric
DELETE /api/v1/metric/some_metric
POST /api/v1/metric json=metric_json
```

and end up with the exact same metric that you started with. Of course, all the related data would be deleted.

Closes #74.