### PR TITLE
Metric api put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 + `GET /api/v1/metric/<metric_name>` has been implemented (#73)
 + `DELETE /api/v1/metric/<metric_name>` has been implemented (#78)
 + `POST /api/v1/metric` has been implemented (#74)
++ `PUT /api/v1/metric/<metric_name>` has been implemented (#75)
 
 
 ## v0.3.0 (2019-01-28)


### PR DESCRIPTION
This adds a `PUT` api for updating metric records.

This API is JSON only for now. I haven't decided if I want to have URL args as an API.

Also note that this code is very similar to the upcoming `PATCH` api. A future MR will consolidate these things.

Closes #75.