### PR TITLE
Metric api patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 + `DELETE /api/v1/metric/<metric_name>` has been implemented (#78)
 + `POST /api/v1/metric` has been implemented (#74)
 + `PUT /api/v1/metric/<metric_name>` has been implemented (#75)
++ `PATCH /api/v1/metric/<metric_name>` has been implemented (#83)
 
 
 ## v0.3.0 (2019-01-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 + `GET /api/v1/metric/<metric_name>` has been implemented (#73)
 + `DELETE /api/v1/metric/<metric_name>` has been implemented (#78)
 + `POST /api/v1/metric` has been implemented (#74)
++ `PUT /api/v1/metric/<metric_name>` has been implemented (#75)
 
 
 ## v0.3.0 (2019-01-28)


### PR DESCRIPTION
This adds a `PATCH` api for updating parts of a metric.

As mentioned in #82, the code is duplicated. A future MR will remedy this.