### PR TITLE
Additional put patch tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 + `PUT /api/v1/metric/<metric_name>` has been implemented (#75)
 + `PATCH /api/v1/metric/<metric_name>` has been implemented (#83)
 + Error responses for the REST API have been refactored (#85)
++ Additional tests for PUT/PATCH metric have been added (#86)
 
 
 ## v0.3.0 (2019-01-28)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def populated_db():
     db.add_metric("foo.bar")
     db.add_metric("metric_with_units", "apples")
     db.add_metric("old_data")
+    db.add_metric("with_everything", "percent", 20, 100)
     db.add_data_point("foo", 15)
     db.add_data_point("foo", 17)
     db.add_data_point("foo", 25)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -110,7 +110,7 @@ def test_get_recent_data(app, populated_db):
 
 def test_get_metrics(app, populated_db):
     rv = db.get_metrics()
-    assert len(rv) == 5
+    assert len(rv) == 6
     assert all(isinstance(x, orm.Metric) for x in rv)
     assert rv[0].name == "empty_metric"
     assert rv[1].metric_id == 2

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -250,6 +250,28 @@ def test_api_patch_metric(client, populated_db):
     assert 'lower_limit' not in d['new_value'].keys()
 
 
+def test_api_patch_metric_doesnt_change_other_values(client, populated_db):
+    name = "with_everything"
+    original = client.get("/api/v1/metric/{}".format(name))
+    assert original.status_code == 200
+    original = original.get_json()
+    assert original['units'] == 'percent'
+    assert original['upper_limit'] == 100.0
+    assert original['lower_limit'] == 20.0
+
+    data = {"lower_limit": 0.2}
+    rv = client.patch("/api/v1/metric/{}".format(name), json=data)
+    assert rv.status_code == 200
+
+    new = client.get("/api/v1/metric/{}".format(name))
+    assert new.status_code == 200
+    new = new.get_json()
+
+    assert new['lower_limit'] == 0.2
+    assert new['units'] == original['units']
+    assert new['upper_limit'] == original['upper_limit']
+
+
 def test_api_patch_metric_not_found(client, populated_db):
     name = "missing"
     data = {"units": "pears"}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -136,7 +136,7 @@ def test_api_post_metric(client, populated_db):
     assert metric in d['message']
     assert d['metric']['name'] == metric
     assert d['metric']['lower_limit'] == lower_limit
-    assert d['metric']['metric_id'] == 6
+    assert d['metric']['metric_id'] == 7
 
 
 def test_api_post_metric_already_exists(client, populated_db):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -174,6 +174,29 @@ def test_api_put_metric(client, populated_db):
     assert d['new_value']['units'] == "lines"
 
 
+def test_api_put_metric_sets_other_values_to_none(client, populated_db):
+    name = "with_everything"
+
+    original = client.get("/api/v1/metric/{}".format(name))
+    assert original.status_code == 200
+    original = original.get_json()
+    assert original['units'] == 'percent'
+    assert original['upper_limit'] == 100.0
+    assert original['lower_limit'] == 20.0
+
+    data = {"name": name}
+    rv = client.put("/api/v1/metric/{}".format(name), json=data)
+    assert rv.status_code == 200
+
+    new = client.get("/api/v1/metric/{}".format(name))
+    assert new.status_code == 200
+    new = new.get_json()
+
+    assert new['units'] is None
+    assert new['upper_limit'] is None
+    assert new['lower_limit'] is None
+
+
 def test_api_put_metric_not_found(client, populated_db):
     name = "missing"
     data = {


### PR DESCRIPTION
This adds additional tests for PUT and PATCH of metrics.

I wasn't 100% sure that PUT was overwriting everything and that PATCH was not editing other fields, so these tests check for that.