### PR TITLE
Use peewee playhouse shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 + `PATCH /api/v1/metric/<metric_name>` has been implemented (#83)
 + Error responses for the REST API have been refactored (#85)
 + Additional tests for PUT/PATCH metric have been added (#86)
++ Make use of peewee's `playhouse` extensions for converting model instances
+  to and from dicts. (#87)
 
 
 ## v0.3.0 (2019-01-28)

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -176,7 +176,7 @@ def get_metric_as_json(metric):
     except DoesNotExist:
         return ErrorResponse.metric_not_found(metric)
 
-    data = utils.format_metric_api_result(raw_data)
+    data = model_to_dict(raw_data)
 
     return jsonify(data)
 

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -390,10 +390,7 @@ def patch_metric(metric):
     # First see if our item actually exists
     try:
         metric = db.Metric.get(db.Metric.name == metric)
-        old_name = metric.name
-        old_units = metric.units
-        old_lower = metric.lower_limit
-        old_upper = metric.upper_limit
+        old = model_to_dict(metric)
     except DoesNotExist:
         return ErrorResponse.metric_not_found(metric)
 
@@ -403,20 +400,9 @@ def patch_metric(metric):
         metric.save()
     except IntegrityError:
         # Failed the unique constraint on Metric.name
-        return ErrorResponse.unique_metric_name_required(old_name, metric.name)
+        return ErrorResponse.unique_metric_name_required(old['name'], metric.name)
 
-    old = {
-        "name": old_name,
-        "units": old_units,
-        "lower_limit": old_lower,
-        "upper_limit": old_upper,
-    }
-    new = {
-        "name": metric.name,
-        "units": metric.units,
-        "lower_limit": metric.lower_limit,
-        "upper_limit": metric.upper_limit,
-    }
+    new = model_to_dict(metric)
 
     # This seems... silly.
     rv = {'old_value': {}, 'new_value': {}}

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -229,17 +229,10 @@ def post_metric():
     # grab that separately.
     new.metric_id = db.Metric.get(db.Metric.name == new.name).metric_id
 
-
     msg = "Added Metric '{}'".format(metric)
     body = {
         "message": msg,
-        "metric": {
-            "name": new.name,
-            "metric_id": new.metric_id,
-            "units": new.units,
-            "upper_limit": new.upper_limit,
-            "lower_limit": new.lower_limit,
-        }
+        "metric": model_to_dict(new)
     }
     return jsonify(body), 201
 

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -183,25 +183,6 @@ def format_data(data, units=None):
     return {'rows': data, "units": units}
 
 
-def format_metric_api_result(metric):
-    """
-    Format Metric information in a jsonify-able structure.
-
-    Parameters
-    ----------
-    metric : :class:`peewee.ModelSelect`
-        The metric to act on.
-    """
-    rv = {
-        'metric_id': metric.metric_id,
-        'name': metric.name,
-        'units': metric.units,
-        'upper_limit': metric.upper_limit,
-        'lower_limit': metric.lower_limit,
-    }
-    return rv
-
-
 def parse_socket_data(data):
     """
     Parse socket data to a dict suitable for sending to ``/api/v1/data``.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,9 +125,3 @@ def test_parse_socket_data(value, expected):
 def test_parse_socket_data_raises_value_error(value):
     with pytest.raises(ValueError):
         utils.parse_socket_data(value)
-
-
-def test_format_metric_api_result(raw_metric):
-    rv = utils.format_metric_api_result(raw_metric)
-    assert isinstance(rv, dict)
-    assert rv['name'] == 'foo'


### PR DESCRIPTION
There were many places where I was manually making dicts. `peewee` has some nice extensions that make these areas obsolete.

This PR updates those areas, at least for `routes.py`.

We are also able to completely remove one of our functions because the peewee extension `model_to_dict` function performed exactly the same operation.