### PR TITLE
Update peewee-moves to 2.0.1 (support TimestampField)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 + Additional tests for PUT/PATCH metric have been added (#86)
 + Make use of peewee's `playhouse` extensions for converting model instances
   to and from dicts. (#87)
++ `peewee-moves` was updated to v2.0.1.
 
 
 ## v0.3.0 (2019-01-28)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ flask==1.0.2
 peewee==3.8.0
 requests==2.21.0
 celery[redis]==4.2.1
-peewee-moves==2.0.0
+peewee-moves==2.0.1


### PR DESCRIPTION
Update peewee-moves to 2.0.1 (support TimestampField)