### PR TITLE
Refactor url links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 + Documentation is now reStructuredText and is hosted by ReadTheDocs (#91)
 + Switched to using `loguru` for logging. (#94)
 + Renamed some function arguments to be more clear. (#89)
++ Removed a hack that caused plot urls to be generated client-side. Was
+  blocking #47. (#100)
 
 
 ## v0.3.0 (2019-01-28)

--- a/src/trendlines/templates/trendlines/index.html
+++ b/src/trendlines/templates/trendlines/index.html
@@ -23,14 +23,11 @@ $(function () {
 
   // Go to data pages if they exist, otherwise just open the tree.
   tree.on('select_node.jstree', function(e, data) {
-    // We can't send JS vars into Jinja/url_for, so we hack in a placeholder
-    // that we'll swap out later. There's got to be a better way!
-    var path = "{{ url_for('pages.plot', metric='PLACEHOLDER') }}"
-
     // jsTree puts the original data structure in a nested object
     // called 'original'. How original of them. Hahaha I crack myself up.
-    if (data.node.original.is_link) {
-      var expected = path.replace("PLACEHOLDER", data.node.id);
+    // If `url` is defined, take us there.
+    if (data.node.original.url !== null) {
+      var expected = data.node.original.url;
       var new_href = document.location.origin + expected;
 
       // Take the user to the plot page.

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -7,6 +7,7 @@ from datetime import timezone
 
 from flask import current_app
 from flask import jsonify
+from flask import url_for
 
 
 @contextmanager
@@ -78,17 +79,18 @@ def format_metric_for_jstree(metric):
     Returns
     -------
     dict
-        A dict with the following keys: id, parent, text, is_link
+        A dict with the following keys: id, parent, text, url
     """
     parent = get_metric_parent(metric)
-    return {"id": metric, "parent": parent, "text": metric, "is_link": True}
+    url = url_for('pages.plot', metric=metric)
+    return {"id": metric, "parent": parent, "text": metric, "url": url}
 
 
 def build_jstree_data(metrics):
     """
     Build a list of dicts consumable by jsTree.
 
-    Fills in missing parent nodes and gives them a ``"is_link": False`` item.
+    Fills in missing parent nodes.
 
     Parameters
     ----------
@@ -105,7 +107,7 @@ def build_jstree_data(metrics):
     data : list of dict
         A JSON-serializable list of dicts. Each dict has at least ``id`` and
         ``parent`` keys. If the metric doesn't exist (it's just a placeholder
-        parent), then the dict will have the ``"is_link": False`` item.
+        parent), then the value of the ``url`` key will be ``None``.
 
     Notes
     -----
@@ -122,11 +124,11 @@ def build_jstree_data(metrics):
        # Spacing added for readability
        # The `text` key is removed for readabiity.
        [
-        {"id": "foo",         "parent": "#",       "is_link": True },
-        {"id": "foo.bar",     "parent": "foo",     "is_link": True },
-        {"id": "bar",         "parent": "#",       "is_link": False},
-        {"id": "bar.baz",     "parent": "bar",     "is_link": False},
-        {"id": "bar.baz.biz", "parent": "bar.baz", "is_link": True },
+        {"id": "foo",         "parent": "#",       "url": "/plot/foo"         },
+        {"id": "foo.bar",     "parent": "foo",     "url": "/plot/foo.bar"     },
+        {"id": "bar",         "parent": "#",       "url": None                },
+        {"id": "bar.baz",     "parent": "bar",     "url": None                },
+        {"id": "bar.baz.biz", "parent": "bar.baz", "url": "/plot/bar.baz.biz" },
        ]
     """
     # First go through and make all of our existing links
@@ -149,7 +151,8 @@ def build_jstree_data(metrics):
         new = {"id": m['parent'],
                "parent": new_parent,
                "text": m['parent'],
-               "is_link": False}
+               "url": None,
+               }
         data.append(new)
 
     # Lastly sort things in a predictable fashion.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,3 +110,9 @@ def app_context(app):
     """
     with app.app_context():
         yield app
+
+
+@pytest.fixture
+def test_request_context(app):
+    with app.test_request_context():
+        yield app

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,35 +45,40 @@ def test_format_metric_for_jstree(test_request_context, data, expected):
 
 @pytest.mark.parametrize("metrics, expected", [
     (["foo", "foo.bar"], [
-        {"id": "foo", "parent": "#", "text": "foo", "is_link": True},
-        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
+        {"id": "foo", "parent": "#", "text": "foo",
+         "url": "/plot/foo"},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
+         "url": "/plot/foo.bar"},
         ]
      ),
     (["foo.bar.baz"], [
-        {"id": "foo", "parent": "#", "text": "foo", "is_link": False},
-        {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-         "is_link": False},
+        {"id": "foo", "parent": "#", "text": "foo", "url": None},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "url": None},
         {"id": "foo.bar.baz", "parent": "foo.bar", "text": "foo.bar.baz",
-         "is_link": True},
+         "url": "/plot/foo.bar.baz"},
         ]
      ),
     (["foo.bar", "foo.baz"], [
-        {"id": "foo", "parent": "#", "text": "foo", "is_link": False},
-        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
-        {"id": "foo.baz", "parent": "foo", "text": "foo.baz", "is_link": True},
+        {"id": "foo", "parent": "#", "text": "foo", "url": None},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
+         "url": "/plot/foo.bar"},
+        {"id": "foo.baz", "parent": "foo", "text": "foo.baz",
+         "url": "/plot/foo.baz"},
         ]
      ),
     (["foo", "foo.bar", "bar.baz.biz"], [
-        {"id": "bar", "parent": "#", "text": "bar", "is_link": False},
-        {"id": "bar.baz", "parent": "bar", "text": "bar.baz", "is_link": False},
+        {"id": "bar", "parent": "#", "text": "bar", "url": None},
+        {"id": "bar.baz", "parent": "bar", "text": "bar.baz", "url": None},
         {"id": "bar.baz.biz", "parent": "bar.baz", "text": "bar.baz.biz",
-         "is_link": True},
-        {"id": "foo", "parent": "#", "text": "foo", "is_link": True},
-        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "is_link": True},
+         "url": "/plot/bar.baz.biz"},
+        {"id": "foo", "parent": "#", "text": "foo",
+         "url": "/plot/foo"},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
+         "url": "/plot/foo.bar"},
        ]
      )
 ])
-def test_build_jstree_data(metrics, expected):
+def test_build_jstree_data(test_request_context, metrics, expected):
     rv = utils.build_jstree_data(metrics)
     assert rv == expected
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,13 +30,15 @@ def test_get_metric_parent(metric, expected):
 
 
 @pytest.mark.parametrize("data, expected", [
-    ("foo", {"id": "foo", "parent": "#", "text": "foo", "is_link": True}),
+    ("foo", {"id": "foo", "parent": "#", "text": "foo",
+             "url": "/plot/foo"}),
     ("foo.bar", {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-                 "is_link": True}),
+                 "url": "/plot/foo.bar"}),
     ("foo.bar.baz", {"id": "foo.bar.baz", "parent": "foo.bar",
-                     "text": "foo.bar.baz", "is_link": True}),
+                     "text": "foo.bar.baz",
+                     "url": "/plot/foo.bar.baz"}),
 ])
-def test_format_metric_for_jstree(data, expected):
+def test_format_metric_for_jstree(test_request_context, data, expected):
     rv = utils.format_metric_for_jstree(data)
     assert rv == expected
 


### PR DESCRIPTION
This moves plot URL link generation to server-side and makes the logic a bit more reasonable.

Instead of having a boolean value for `is_link`, we instead use a nullable `url` key. If given, then the metric exists and can be plotted.

Closes #100.