### PR TITLE
Use tmp_path fixture for database during tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 + `create_db` was moved out of `app_factory.py` and into `orm.py`. (#115)
++ All files created during tests are now made in the `/tmp` directory. (#44)
 
 
 ## 0.5.0 (2019-02-28)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,20 +27,13 @@ def caplog(_caplog):
 
 
 @pytest.fixture
-def app():
+def app(tmp_path):
     """
     A test app.
 
     Needed to do things like creating a test client.
     """
-    db_file = Path("test.db")
-
-    # Unlink the db_file on setup instead of on teardown. This is so we can
-    # check what's in the database after a test has run.
-    try:
-        db_file.unlink()
-    except FileNotFoundError:
-        pass
+    db_file = Path(tmp_path) / "test.db"
 
     app = create_app()
 


### PR DESCRIPTION
Use tmp_path fixture for database during tests.

We no longer need to unlink the file ourselves, since it'll get cleaned
up by pytest or by the file system.

Fixes #44.