### PR TITLE
Automatic migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Unreleased
 + `create_db` was moved out of `app_factory.py` and into `orm.py`. (#115)
 + All files created during tests are now made in the `/tmp` directory. (#44)
++ Migrations are now performed automatically when the flask app is created
+  (when the first request comes in to WSGI). (#71, #114)
 
 
 ## 0.5.0 (2019-02-28)

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -20,7 +20,9 @@ connection speed.
     while we're doing things.
 3.  Backup your database.
 4.  Pull the new image.
-5.  Perform database migrations.
+5.  (Optional) Manually perform database migrations. As of #117 (release
+    v0.6.0), migrations are automatically performed upon recieving the first
+    request after server start (when the WSGI process starts).
 6.  Bring up the stack.
 
 If you're using a specific version release, update your ``docker-compose.yml``
@@ -54,7 +56,7 @@ Then run the rest of the steps:
            --database sqlite:///data/internal.db \
            status
 
-   # Run the migrations
+   # Optional: Run the migrations
    $ docker-compose run --rm --no-deps trendlines \
        peewee-db \
            --directory /trendlines/migrations \

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import shutil
+from datetime import datetime
 from pathlib import Path
 
 from peewee import SqliteDatabase
@@ -9,8 +11,11 @@ from peewee import TimestampField
 from peewee import ForeignKeyField
 from peewee import CharField
 from peewee import OperationalError
+from peewee_moves import DatabaseManager
 
 from trendlines import logger
+from trendlines import utils
+from trendlines.__about__ import __project_url__
 
 
 DB_OPTS = {
@@ -95,33 +100,102 @@ def create_db(name):
     """
     Create the database and the tables.
 
-    Does nothing if the tables already exist. Well, techinically it just
-    connects and disconnects - ``create_tables`` is a noop.
+    Applies any missing migrations. Does nothing if all migrations
+    have been applied.
 
     Parameters
     ----------
     name : str
-        The name of the database, as given by ``app.config['DATABASE']``.
+        The name/path of the database, as given by ``app.config['DATABASE']``.
     """
-    logger.debug("Creating database: '%s'." % name)
-    db.init(name, pragmas=DB_OPTS)
+    #  import pdb; pdb.set_trace()
+    # Convert to a Path object because I like working with those better.
+    full_path = Path(name).resolve()
+
+    file_exists = full_path.exists()
+    if file_exists:
+        logger.debug("Connecting to existing database: '%s'." % full_path)
+    else:
+        logger.debug("Creating new database: '%s'" % full_path)
+
+    db.init(str(full_path), pragmas=DB_OPTS)
 
     try:
+        # This will create the file if it doesn't exist.
         db.connect()
     except OperationalError:
-        # .resolve() will fail for missing paths, and the `strit=False` arg
-        # wasn't added until 3.6. Since dev environment is 3.5 I need
-        # this try..except block.
-        try:        # pragma: no cover
-            full_path = Path(name).resolve()
-        except FileNotFoundError:
-            full_path = name
-        logger.error("Unable to open database file '%s'" % full_path)
+        # Try to figure out why OperationalError happened.
+        if file_exists:
+            msg = ("Database file %s exists, but we're unable to connect."
+                   " Perhaps the permissions are incorrect?")
+            logger.error(msg % full_path)
+        else:
+            msg = ("Unable to create %s. Perhaps the parent folder is missing"
+                   " or permissions are incorrect?")
+            logger.error(msg % full_path)
+        logger.error("Unable to create/open database file '%s'" % full_path)
         raise
 
-    tables = [
-        Metric,
-        DataPoint,
-    ]
-    db.create_tables(tables)
+    # Either way, we want to run migrations. However, we only need to make a
+    # backup if the file already exists.
+    if file_exists:
+        # Create a backup before doing anything.
+        backup_file = utils.backup_file(full_path)
+        logger.debug("Created database backup file: {}".format(backup_file))
+
+    # This will edit the database file, creating the `migration_history`
+    # table if needed. Hence why we do it *after* the backup.
+    try:
+        manager = DatabaseManager(db)
+    except PermissionError:
+        # When runnng in the docker container, this will attempt to create
+        # a `/migrations` directory. It should be `/trendlines/migrations`.
+        # If this still fails, let the error propogate but make sure to
+        # close the db connection
+        try:
+            msg = "Failed to open default migration directory, trying '%s'"
+            alt_dir = "/trendlines/migrations"
+            logger.debug(msg % alt_dir)
+            manager = DatabaseManager(db, directory=alt_dir)
+            logger.debug("Success")
+        except PermissionError:
+            raise
+        finally:
+            db.close()
+
+    # Check the status. Creating a new file means we'll need migrations.
+    # However, we don't need to check for that because it's guaranteed
+    # that a new file will have len(manager.diff) > 0
+    needs_migrations = len(manager.diff) > 0
+
+    if needs_migrations:
+        logger.info("Missing migrations: {}".format(manager.diff))
+
+        # Apply the migrations
+        success = manager.upgrade()
+        if success:
+            logger.info("Successfully applied database migrations.")
+        elif file_exists:
+            # revert our changes by restoring the backup
+            msg = ("Failed to apply database migrations. Reverting to backup"
+                   " file. Please submit an issue at {} with details.")
+            logger.critical(msg.format(__project_url__))
+            shutil.copy(str(backup_file), str(full_path))
+        else:
+            # It's a new file, so no backup was made.
+            msg = ("Failed to apply database migrations to the new file."
+                   " Please see the logs for more info.")
+            logger.critical(msg)
+    else:
+        logger.info("Database is up to date. No migrations to apply.")
+        # Since we didn't make any changes, we can remove the backup file.
+        # Is it possible to ever have backup_file not exist if we didn't
+        # apply migrations?
+        # No, because not applying migrations implies that the file already
+        # existed, and if the file already existed then a backup was made.
+        # Thus we don't need to check for FileNotFoundError.
+        backup_file.unlink()
+        logger.debug("Removed superfluous backup file: %s" % backup_file)
+
+    # Make sure to close the database if things went well.
     db.close()

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """
 """
+import shutil
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timezone
+from pathlib import Path
 
 from flask import current_app
 from flask import jsonify
@@ -222,3 +224,26 @@ def parse_socket_data(data):
     d = {"metric": metric, "value": value, "time": time}
 
     return d
+
+
+def backup_file(path, ts_format="%Y%m%d_%H%M%S"):
+    """
+    Backup a file by copying it and appending a timestamp to the name.
+
+    Parameters
+    ----------
+    path : :class:`pathlib.Path`
+        The file to back up.
+    ts_format : str, optional
+        The format of the timestamp to append to the name. Defaults to
+        ``"%Y%m%d_%H%M%S"``: ``20190301_164832``
+
+    Returns
+    -------
+    backup_file : :class:`pathlib.Path`
+        The path to the newly created backup file.
+    """
+    backup_file = "{}.{}".format(path, datetime.now().strftime(ts_format))
+    backup_file = Path(backup_file)
+    shutil.copy(str(path), str(backup_file))
+    return backup_file

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,13 +1,77 @@
 # -*- coding: utf-8 -*-
 """
 """
+import hashlib
+import sqlite3
+from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from freezegun import freeze_time
 from peewee import OperationalError
+from peewee import SqliteDatabase
+from peewee_moves import DatabaseManager
 
 from trendlines import orm
+
+
+def _hash_file(path, algorithm=hashlib.md5):
+    """
+    Return the hash of a file. Not very efficient but I don't care.
+
+    Parameters
+    ----------
+    path : str or :class:`pathlib.Path`
+        The path to the file to hash.
+    method : function, optional
+        One of the ``hashlib`` algorithms. Defaults to ``hashlib.md5``
+
+    Returns
+    -------
+    str
+        The hex representation of the hash.
+    """
+    return algorithm(open(str(path), 'rb').read()).hexdigest()
+
+
+@pytest.fixture
+def up_to_date_db(tmp_path):
+    """
+    Return a database that has all migrations applied.
+    """
+    path = tmp_path / "foo.db"
+    manager = DatabaseManager(SqliteDatabase(str(path)))
+    manager.upgrade()
+    yield path
+    path.unlink()
+
+
+@pytest.fixture
+def outdated_db(up_to_date_db):
+    """
+    Return a database file that is missing some migrations.
+    """
+    # Rename things to avoid confusion
+    path = up_to_date_db
+    # Start with an up-to-date database, then downgrade
+    manager = DatabaseManager(SqliteDatabase(str(path)))
+    manager.downgrade()
+    yield path
+
+
+@pytest.fixture
+def broken_db(outdated_db):
+    """
+    Return a database file that is broken and cannot have migrations applied.
+    """
+    path = outdated_db
+    conn = sqlite3.connect(str(path))
+    c = conn.cursor()
+    c.execute('DROP TABLE datapoint;')
+    conn.commit()
+    conn.close()
+    yield path
 
 
 def test_metric_str():
@@ -33,5 +97,110 @@ def test_create_db_logs_and_raises_operational_error(caplog):
     with pytest.raises(OperationalError):
         orm.create_db("foo")
 
-    assert "Unable to open database file" in caplog.text
+    assert "Unable to create/open database file" in caplog.text
     assert "foo" in caplog.text
+
+
+def test_create_db_new_file(tmp_path, caplog):
+    path = tmp_path / "foo.db"
+    orm.create_db(str(path))
+    # if the function worked the file should now exist.
+    assert path.exists()
+    assert "Missing migrations:" in caplog.text
+    # for new files, all migrations should be missing. If the 1st is missing,
+    # that implies that the rest are missing as well.
+    assert "0001" in caplog.text
+
+
+def test_create_db_nothing_to_do(up_to_date_db, caplog):
+    orm.create_db(str(up_to_date_db))
+    assert "Database is up to date." in caplog.text
+
+
+def test_create_db_applies_missing_migrations(outdated_db, caplog):
+    orm.create_db(str(outdated_db))
+    assert "Missing migrations:" in caplog.text
+    assert "Created database backup" in caplog.text
+    assert "Successfully applied database migrations" in caplog.text
+
+
+@freeze_time("2019-02-28 15:02:02")
+def test_create_db_failure(broken_db, caplog):
+    # orm.db.init changes the file so we can't look at a "before" hash.
+
+    # Run the migration (will fail)
+    orm.create_db(str(broken_db))
+
+    # Make sure our original file and backup files exist, and are the same
+    backup_file = Path("{}.{}".format(str(broken_db), "20190228_150202"))
+    assert broken_db.exists()
+    assert backup_file.exists()
+    assert _hash_file(broken_db) == _hash_file(backup_file)
+
+    # and lastly check our logs.
+    assert "Missing migrations:" in caplog.text
+    assert "Created database backup" in caplog.text
+    assert "Failed to apply database migrations" in caplog.text
+    assert "Reverting to backup file" in caplog.text
+
+
+@patch("trendlines.orm.db.connect", MagicMock(side_effect=OperationalError))
+def test_create_db_operational_error_and_file_exists(up_to_date_db, caplog):
+    with pytest.raises(OperationalError):
+        orm.create_db(str(up_to_date_db))
+
+    assert "but we're unable to connect" in caplog.text
+
+
+@patch("peewee_moves.DatabaseManager.upgrade", MagicMock(return_value=False))
+def test_create_db_migration_failure_on_new_file(tmp_path, caplog):
+    orm.create_db(str(tmp_path / "foo.db"))
+    expected = "Failed to apply database migrations to the new file"
+    assert expected in caplog.text
+
+
+@patch("trendlines.orm.DatabaseManager",
+    MagicMock(side_effect=PermissionError)
+)
+def test_create_db_run_migrations_in_docker_fails(outdated_db, caplog):
+    with pytest.raises(PermissionError):
+        orm.create_db(str(outdated_db))
+    assert "Failed to open default migration directory" in caplog.text
+    assert "Success" not in caplog.text
+    assert "Successfully applied database migrations" not in caplog.text
+
+
+def _fake_db_manager():
+    """
+    Needed by ``test_create_db_run_migrtations_in_docker``.
+
+    Because of poor design choices, we call
+    :class:`peewee_moves.DatabaseManager` twice within
+    :func:`orm.create_db`. We need to have the first call
+    raise ``PermissionError`` and the second return a correct
+    :class:~`peewee_moves.DatabaseManager` object.
+
+    Having the mocked object return two different values is pretty easy:
+    simply set your ``side_effect`` to be an iterable.
+
+    I was unable to figure out how to get the 2nd one to work. I thought
+    that using :attr:`unittest.mark.DEFAULT` would work, but the issue
+    there is that ``manager.diff`` would return something that resulted
+    in ``needs_migrations`` being ``False``. We need that to be ``True``.
+
+    So I decided to just mock the whole 2nd ``side_effect``.
+    """
+    db_manager = MagicMock()
+    db_manager.diff = ["0005"]
+    db_manager.upgrade = MagicMock(return_value=True)
+    return db_manager
+
+
+@patch("trendlines.orm.DatabaseManager",
+    MagicMock(side_effect=[PermissionError, _fake_db_manager()])
+)
+def test_create_db_run_migrations_in_docker(outdated_db, caplog):
+    orm.create_db(str(outdated_db))
+    assert "Failed to open default migration directory" in caplog.text
+    assert "Success" in caplog.text
+    assert "Successfully applied database migrations" in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from flask import Response
 from freezegun import freeze_time
 
 from trendlines import utils
+from .test_orm import _hash_file
 
 
 def test_adjust_jsonify_mimetype(app_context):
@@ -132,3 +133,13 @@ def test_parse_socket_data(value, expected):
 def test_parse_socket_data_raises_value_error(value):
     with pytest.raises(ValueError):
         utils.parse_socket_data(value)
+
+
+@freeze_time("2019-01-25T04:32:28Z")
+def test_backup_file(tmp_path):
+    path = tmp_path / "foo.bar"
+    path.write_text("hello")
+    rv = utils.backup_file(path)
+    assert rv.exists()
+    assert rv.name == "foo.bar.20190125_043228"
+    assert _hash_file(path) == _hash_file(rv)


### PR DESCRIPTION
This makes migrations happen automatically the first time a request comes in.

+ Adds a utility function to back up a file
+ refactors `orm.create_db` significantly
+ Updates docs

Fixes #71 and #114.