### PR TITLE
Dont have tests create internal db file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def app(tmp_path):
 
     Needed to do things like creating a test client.
     """
-    db_file = Path(tmp_path) / "test.db"
+    db_file = Path(str(tmp_path)) / "test.db"
 
     # Mock out create_db - we'll do it later. If we let it happen now, then
     # a database will be made using the `app.config['DATABASE']` value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ Global PyTest fixtures.
 """
 import logging
 from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from _pytest.logging import caplog as _caplog
@@ -40,7 +42,11 @@ def app(tmp_path):
     """
     db_file = Path(tmp_path) / "test.db"
 
-    app = create_app()
+    # Mock out create_db - we'll do it later. If we let it happen now, then
+    # a database will be made using the `app.config['DATABASE']` value,
+    # which we don't want. (since that'll typically be `./internal.db`)
+    with patch('trendlines.orm.create_db', MagicMock()):
+        app = create_app()
 
     # Since the `create_db` function modifies orm.db directly, we can simply
     # call it here. I guess *technically* what's happening is whatever

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -11,6 +11,21 @@ import pytest
 from trendlines import app_factory
 
 
+@pytest.fixture(autouse=True)
+def mock_create_db():
+    """
+    Mock out ``orm.create_db`` used by ``app_factory.create_app()``.
+
+    We don't want the database file created.
+
+    This fixture is autoused for all tests in this module. Other modules
+    rely on the the ``conftest.app`` fixture, which also performs this
+    patching.
+    """
+    with patch('trendlines.orm.create_db', MagicMock()):
+        yield
+
+
 def test_create_app(tmp_path, monkeypatch, caplog):
     # We need to touch the file or else we'll hit the FileNotFoundError
     path = tmp_path / "foo.cfg"


### PR DESCRIPTION
This updates tests so that an `internal.db` file is not created in the current working dir.

Now all database files are made in the `/tmp` dir, yay!