### PR TITLE
Drop py35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 dist: xenial
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 + All files created during tests are now made in the `/tmp` directory. (#44)
 + Migrations are now performed automatically when the flask app is created
   (when the first request comes in to WSGI). (#71, #114)
++ Dropped support for Python 3.5 (#119)
 
 
 ## 0.5.0 (2019-02-28)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     packages=find_packages(where='src'),
     include_package_data=False,
 
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=requires,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def app(tmp_path):
 
     Needed to do things like creating a test client.
     """
-    db_file = Path(str(tmp_path)) / "test.db"
+    db_file = Path(tmp_path) / "test.db"
 
     # Mock out create_db - we'll do it later. If we let it happen now, then
     # a database will be made using the `app.config['DATABASE']` value,


### PR DESCRIPTION
I don't think I need to support Python 3.5, so I'm dropping it.

Reasons to drop:
+ The recommended way to run this is with docker, which uses 3.7
+ Development is done on 3.6
+ Ubuntu 18.04 LTS comes with 3.6
+ I'm lazy and don't want to figure out why [Job #224.1](https://travis-ci.org/dougthor42/trendlines/jobs/500610150) is failing.

Reasons to keep:
+ Debian Stretch uses 3.5.