### PR TITLE
API: get all metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 + Migrations are now performed automatically when the flask app is created
   (when the first request comes in to WSGI). (#71, #114)
 + Dropped support for Python 3.5 (#119)
++ Added the REST API to get all metrics (#120)
 
 
 ## 0.5.0 (2019-02-28)

--- a/src/trendlines/error_responses.py
+++ b/src/trendlines/error_responses.py
@@ -28,6 +28,12 @@ class ErrorResponseType(Enum):
 class ErrorResponse(object):
 
     @classmethod
+    def no_data(cls):
+        """No data exists in the table."""
+        detail = "No data found."
+        return error_response(404, ErrorResponseType.NO_DATA, detail)
+
+    @classmethod
     def metric_not_found(cls, name):
         detail = "The metric '{}' does not exist".format(name)
         return error_response(404, ErrorResponseType.NOT_FOUND, detail)

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -176,7 +176,15 @@ def api_get_metrics():
     """
     Return a list of all metrics in the database.
     """
-    pass
+    logger.debug("api: GET all metrics")
+    raw_data = db.get_metrics()
+    if len(raw_data) == 0:
+        # do a thing.
+        return ErrorResponse.no_data()
+
+    data = [model_to_dict(m) for m in raw_data]
+
+    return jsonify(data)
 
 
 @api.route("/api/v1/metric/<metric_name>", methods=["GET"])

--- a/tests/test_error_responses.py
+++ b/tests/test_error_responses.py
@@ -85,7 +85,7 @@ def test_rfc_error_response_content_type(rfc_object):
     (ErrorResponse.unique_metric_name_required, ("foo", "bar")),
     (ErrorResponse.missing_required_key, ("foo", )),
 ])
-def test_error_response_metric_not_found(app_context, caplog, method, args):
+def test_error_response_class_methods(app_context, caplog, method, args):
     rv = method(*args)
     assert isinstance(rv, tuple)
     assert len(rv) == 2

--- a/tests/test_error_responses.py
+++ b/tests/test_error_responses.py
@@ -84,9 +84,13 @@ def test_rfc_error_response_content_type(rfc_object):
     (ErrorResponse.metric_already_exists, ("foo", )),
     (ErrorResponse.unique_metric_name_required, ("foo", "bar")),
     (ErrorResponse.missing_required_key, ("foo", )),
+    (ErrorResponse.no_data, None),
 ])
 def test_error_response_class_methods(app_context, caplog, method, args):
-    rv = method(*args)
+    if args is None:
+        rv = method()
+    else:
+        rv = method(*args)
     assert isinstance(rv, tuple)
     assert len(rv) == 2
     assert rv[0].is_json

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -339,3 +339,21 @@ def test_api_patch_metric_duplicate_name(client, populated_db):
     assert old_name in d['detail']
     assert new_name in d['detail']
     assert "Unable to change metric name" in d['detail']
+
+
+def test_api_get_metrics(client, populated_db):
+    rv = client.get("/api/v1/metric")
+    assert rv.status_code == 200
+    assert rv.is_json
+    d = rv.get_json()
+    assert len(d) == 6
+    assert "metric_id" in d[0].keys()
+    assert d[0]['name'] == "empty_metric"
+
+
+def test_api_get_metrics_no_data(client):
+    rv = client.get("/api/v1/metric")
+    assert rv.status_code == 404
+    assert rv.is_json
+    d = rv.get_json()
+    assert "No data" in d['detail']


### PR DESCRIPTION
This adds an api route to get all metrics in the database.

Also adds the `ErrorResponse.no_data` class method, as it's a prereq for the route.