### PR TITLE
Swagger docs via flask rest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 + `db.add_data_point` was renamed to `db.insert_datapoint` to match with
   future API naming conventions. (#123)
 + Added an internal api for datapoints to `db.py`. (#125)
++ The REST api is now viewable via a Swagger (or ReDoc!) web page! (#34)
 
 
 ## 0.5.0 (2019-02-28)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests==2.21.0
 celery[redis]==4.2.1
 peewee-moves==2.0.1
 loguru==0.2.5
+marshmallow-peewee==2.2.0
+flask-rest-api==0.14.0

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -40,7 +40,10 @@ def create_app():
 
     logger.debug("Registering blueprints.")
     app.register_blueprint(routes.pages)
-    app.register_blueprint(routes.api)
+
+    # Initialize flask-rest-api for OpenAPI (Swagger) documentation
+    routes.api_class.init_app(app)
+    routes.api_class.register_blueprint(routes.api)
 
     # Create the database file and populate initial tables if needed.
     orm.create_db(app.config['DATABASE'])

--- a/src/trendlines/default_config.py
+++ b/src/trendlines/default_config.py
@@ -35,3 +35,10 @@ DEBUG = False
 TESTING = False
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024   # 16MB
 SECRET_KEY = b"change me"
+
+# Flask-Rest-Api / OpenAPI ######################
+OPENAPI_VERSION = '3.0.2'
+OPENAPI_URL_PREFIX = '/api'
+OPENAPI_REDOC_PATH = '/redoc'
+OPENAPI_SWAGGER_UI_PATH = ''
+OPENAPI_SWAGGER_UI_VERSION = '3.19.5'

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -6,10 +6,13 @@ from datetime import timezone
 from functools import partial
 
 from marshmallow_peewee import ModelSchema
-from flask import Blueprint
+from flask import Blueprint as FlaskBlueprint
 from flask import jsonify
 from flask import render_template as _render_template
 from flask import request
+
+from flask_rest_api import Api
+from flask_rest_api import Blueprint
 
 # peewee
 from peewee import DoesNotExist
@@ -24,19 +27,23 @@ from . import orm
 from .error_responses import ErrorResponse
 from . import utils
 
-pages = Blueprint('pages', __name__)
-api = Blueprint('api', __name__)
+pages = FlaskBlueprint('pages', __name__)
+api_class = Api()
+api = Blueprint("api", __name__,
+                description="All API.")
 
 
 # Make sure all pages show our version.
 render_template = partial(_render_template, version=__version__)
 
 
+@api_class.definition("Metrics")
 class MetricSchema(ModelSchema):
     class Meta:
         model = orm.Metric
 
 
+@api_class.definition("DataPoints")
 class DataPointSchema(ModelSchema):
     class Meta:
         model = orm.DataPoint

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timezone
 from functools import partial
 
+from marshmallow_peewee import ModelSchema
 from flask import Blueprint
 from flask import jsonify
 from flask import render_template as _render_template
@@ -19,6 +20,7 @@ from playhouse.shortcuts import update_model_from_dict
 from trendlines import logger
 from trendlines.__about__ import __version__
 from . import db
+from . import orm
 from .error_responses import ErrorResponse
 from . import utils
 
@@ -28,6 +30,16 @@ api = Blueprint('api', __name__)
 
 # Make sure all pages show our version.
 render_template = partial(_render_template, version=__version__)
+
+
+class MetricSchema(ModelSchema):
+    class Meta:
+        model = orm.Metric
+
+
+class DataPointSchema(ModelSchema):
+    class Meta:
+        model = orm.DataPoint
 
 
 @pages.route('/', methods=['GET'])


### PR DESCRIPTION
This adds some basic Swagger (and ReDoc) documentation and web interface.

It uses [flask-rest-api](https://github.com/Nobatek/flask-rest-api) to serve things. The API is viewable at `http://$SERVER/api` by default, but is configurable by setting `OPENAPI_URL_PREFIX` and `OPENAPI_SWAGGER_UI_PATH`.

Fixes #34.