### PR TITLE
Organize api docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 + Added an internal api for datapoints to `db.py`. (#125)
 + The REST api is now viewable via a Swagger (or ReDoc!) web page! (#34)
 + Core API routes have been refactored to use Flask's Pluggable Views. (#128)
++ Sorted the Swagger API into logical blueprints by Schema/MethodView. (#133)
 
 
 ## 0.5.0 (2019-02-28)

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -44,6 +44,7 @@ def create_app():
     # Initialize flask-rest-api for OpenAPI (Swagger) documentation
     routes.api_class.init_app(app)
     routes.api_class.register_blueprint(routes.api)
+    routes.api_class.register_blueprint(routes.api_datapoint)
 
     # Create the database file and populate initial tables if needed.
     orm.create_db(app.config['DATABASE'])

--- a/src/trendlines/app_factory.py
+++ b/src/trendlines/app_factory.py
@@ -45,6 +45,7 @@ def create_app():
     routes.api_class.init_app(app)
     routes.api_class.register_blueprint(routes.api)
     routes.api_class.register_blueprint(routes.api_datapoint)
+    routes.api_class.register_blueprint(routes.api_metric)
 
     # Create the database file and populate initial tables if needed.
     orm.create_db(app.config['DATABASE'])

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -34,6 +34,8 @@ api = Blueprint("api", __name__,
                 description="All API.")
 api_datapoint = Blueprint("DataPoints", __name__,
                           description="CRUD datapoint(s)")
+api_metric = Blueprint("Metrics", __name__,
+                       description="CRUD metric(s)")
 
 
 # Make sure all pages show our version.
@@ -187,7 +189,7 @@ class DataPointById(MethodView):
             return "", 204
 
 
-@api.route("/api/v1/metric")
+@api_metric.route("/api/v1/metric")
 class Metric(MethodView):
     def get(self):
         """
@@ -258,7 +260,7 @@ class Metric(MethodView):
         return jsonify(body), 201
 
 
-@api.route("/api/v1/metric/<metric_name>")
+@api_metric.route("/api/v1/metric/<metric_name>")
 class MetricById(MethodView):
     def get(self, metric_name):
         """

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -32,6 +32,8 @@ pages = FlaskBlueprint('pages', __name__)
 api_class = Api()
 api = Blueprint("api", __name__,
                 description="All API.")
+api_datapoint = Blueprint("DataPoints", __name__,
+                          description="CRUD datapoint(s)")
 
 
 # Make sure all pages show our version.
@@ -132,7 +134,7 @@ def get_data_as_json(metric_name):
     return jsonify(data)
 
 
-@api.route("/api/v1/datapoint")
+@api_datapoint.route("/api/v1/datapoint")
 class DataPoint(MethodView):
     def get(self):
         """
@@ -150,7 +152,7 @@ class DataPoint(MethodView):
         pass
 
 
-@api.route("/api/v1/datapoint/<datapoint_id>")
+@api_datapoint.route("/api/v1/datapoint/<datapoint_id>")
 class DataPointById(MethodView):
     def get(self, datapoint_id):
         """


### PR DESCRIPTION
This organizes the API docs (swagger) into logical blocks based on the schema/MethodView.