### PR TITLE
Allow the 'missing_required_key' error response to accept list/tuples.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 + Core API routes have been refactored to use Flask's Pluggable Views. (#128)
 + Sorted the Swagger API into logical blueprints by Schema/MethodView. (#133)
 + Replaced all instances of port 9999 with port 2003. (#104)
++ The `missing_required_key` error response now accepts lists or tuples.
+  (#137)
 
 
 ## 0.5.0 (2019-02-28)

--- a/src/trendlines/error_responses.py
+++ b/src/trendlines/error_responses.py
@@ -62,7 +62,10 @@ class ErrorResponse(object):
 
     @classmethod
     def missing_required_key(cls, key):
-        detail = "Missing required key 'name'"
+        if isinstance(key, (list, tuple)):
+            detail = "Missing one of required keys: {}".format(key)
+        else:
+            detail = "Missing required key '{}'".format(key)
         return error_response(400, ErrorResponseType.INVALID_REQUEST, detail)
 
 

--- a/tests/test_error_responses.py
+++ b/tests/test_error_responses.py
@@ -84,6 +84,7 @@ def test_rfc_error_response_content_type(rfc_object):
     (ErrorResponse.metric_already_exists, ("foo", )),
     (ErrorResponse.unique_metric_name_required, ("foo", "bar")),
     (ErrorResponse.missing_required_key, ("foo", )),
+    (ErrorResponse.missing_required_key, (["foo", "bar"], )),
     (ErrorResponse.no_data, None),
 ])
 def test_error_response_class_methods(app_context, caplog, method, args):


### PR DESCRIPTION
Allow the 'missing_required_key' error response to accept list/tuples.