### PR TITLE
Helpers for test_routes.py

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -6,6 +6,40 @@ import pytest
 from trendlines import routes
 
 
+API_BASE = "/api/v1"
+
+def metric_url(metric_id=None):
+    """
+    Helper to generate the metric url with ID.
+
+    Examples
+    --------
+    >>> metric_url()
+    "/api/v1/metric"
+    >>> metric_url(5)
+    "/api/v1/metric/5"
+    """
+    if metric_id is not None:
+        return API_BASE + "/metric/{}".format(metric_id)
+    return API_BASE + "/metric"
+
+
+def datapoint_url(datapoint_id=None):
+    """
+    Helper to generate the metric url with ID.
+
+    Examples
+    --------
+    >>> datapoint_url()
+    "/api/v1/datapoint"
+    >>> datapoint_url(5)
+    "/api/v1/datapoint/5"
+    """
+    if datapoint_id is not None:
+        return API_BASE + "/datapoint/{}".format(datapoint_id)
+    return API_BASE + "/datapoint"
+
+
 def test_index(client):
     rv = client.get('/')
     assert rv.status_code == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -113,18 +113,18 @@ def test_api_get_data_as_json_no_data_for_metric(client, populated_db):
 
 def test_api_delete_datapoint(client, populated_db):
     datapoint_id = 6
-    rv = client.delete("/api/v1/datapoint/{}".format(datapoint_id))
+    rv = client.delete(datapoint_url(datapoint_id))
     assert rv.status_code == 204
 
     # Verify it's actually been deleted
     # TODO: needs the datapoint GET route
-    #  after = client.get("/api/v1/datapoint/{}".format(datapoint_id))
+    #  after = client.get(datapoint_url(datapoint_id))
     #  assert after.status_code == 404
 
 
 def test_api_delete_datapoint_not_found(client, populated_db, caplog):
     datapoint_id = 103132
-    rv = client.delete("/api/v1/datapoint/{}".format(datapoint_id))
+    rv = client.delete(datapoint_url(datapoint_id))
     assert rv.status_code == 404
     assert rv.is_json
     d = rv.get_json()


### PR DESCRIPTION
This adds some helpers for `test_routes.py` that make it easier to generate the `Metric` and `DataPoint` API URLs.