### PR TITLE
Use sqlite_ext.AutoIncrementField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   no longer accept strings for metric identification. See the docs for
   additional details. (#140)
 + Minor updates to how the `populated_db` test fixture works (#142)
++ Table PKs are now explicit `AUTOINCREMENT` rather than using SQLite's
+  internal `ROWID`. This will result in increased cpu/memory/disk overhead,
+  but it ensures that PKs cannot be resued. (#143)
 
 
 ## 0.5.0 (2019-02-28)

--- a/migrations/0006_make_primary_keys_autoincrement.py
+++ b/migrations/0006_make_primary_keys_autoincrement.py
@@ -1,0 +1,80 @@
+"""
+make_primary_keys_autoincrement
+date created: 2019-03-28 21:47:26.858802
+"""
+
+# Reminders:
+# + 'single_quotes' denote string literals.
+# + "double_quotes" denote identifiers.
+#     + same with [brackets] and `backticks`, for compatability with MS SQL
+#       and MySQL.
+#       -- https://www.sqlite.org/lang_keywords.html
+# + "So, in most real systems, an index should be created on the child key
+#   columns of each foreign key constraint."
+#   -- https://www.sqlite.org/foreignkeys.html
+
+# Downgrade to the original DDL
+DOWNGRADE = """
+ALTER TABLE "metric" RENAME TO "metric_temp";
+CREATE TABLE IF NOT EXISTS "metric" (
+  "metric_id" INTEGER NOT NULL PRIMARY KEY,
+  "name" VARCHAR(120) NOT NULL,
+  "units" VARCHAR(24),
+  "upper_limit" REAL,
+  "lower_limit" REAL
+);
+INSERT INTO "metric" SELECT * FROM "metric_temp";
+DROP TABLE "metric_temp";
+CREATE UNIQUE INDEX "metric_name" ON "metric" ("name");
+
+ALTER TABLE "datapoint" RENAME TO "datapoint_temp";
+CREATE TABLE IF NOT EXISTS "datapoint" (
+  "datapoint_id" INTEGER NOT NULL PRIMARY KEY,
+  "metric_id" INTEGER NOT NULL,
+  "value" REAL NOT NULL,
+  "timestamp" INTEGER NOT NULL,
+  FOREIGN KEY ("metric_id") REFERENCES "metric" ("metric_id") ON DELETE CASCADE
+);
+INSERT INTO "datapoint" SELECT * FROM "datapoint_temp";
+DROP TABLE "datapoint_temp";
+CREATE INDEX "fakemodel_metric_id" ON "datapoint" ("metric_id");
+"""
+
+# New DDL
+UPGRADE = """
+ALTER TABLE "metric" RENAME TO "metric_temp";
+CREATE TABLE IF NOT EXISTS "metric" (
+  "metric_id"  INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "name"  VARCHAR(120) NOT NULL,
+  "units"  VARCHAR(24),
+  "upper_limit"  REAL,
+  "lower_limit"  REAL
+);
+INSERT INTO "metric" SELECT * FROM "metric_temp";
+DROP TABLE "metric_temp";
+CREATE UNIQUE INDEX "metric_name" ON "metric" ("name");
+
+ALTER TABLE "datapoint" RENAME TO "datapoint_temp";
+CREATE TABLE IF NOT EXISTS "datapoint" (
+  "datapoint_id"  INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "metric_id"  INTEGER NOT NULL,
+  "value"  REAL NOT NULL,
+  "timestamp"  INTEGER NOT NULL,
+  FOREIGN KEY("metric_id") REFERENCES "metric" ( "metric_id" ) ON DELETE CASCADE
+);
+INSERT INTO "datapoint" SELECT * FROM "datapoint_temp";
+DROP TABLE "datapoint_temp";
+CREATE INDEX "datapoint_metric_id" ON "datapoint" ("metric_id");
+"""
+
+
+def upgrade(migrator):
+    for line in UPGRADE.split(";"):
+        sql = line + ";"    # not really needed, but gives me warm fuzzies.
+        migrator.execute_sql(sql)
+
+
+def downgrade(migrator):
+    for line in DOWNGRADE.split(";"):
+        sql = line + ";"    # not really needed, but gives me warm fuzzies.
+        migrator.execute_sql(sql)

--- a/src/trendlines/orm.py
+++ b/src/trendlines/orm.py
@@ -12,6 +12,7 @@ from peewee import ForeignKeyField
 from peewee import CharField
 from peewee import OperationalError
 from peewee_moves import DatabaseManager
+from playhouse.sqlite_ext import AutoIncrementField
 
 from trendlines import logger
 from trendlines import utils
@@ -60,7 +61,7 @@ class Metric(InternalModel):
     Table holding all of the Metric information.
     """
 
-    metric_id = IntegerField(primary_key=True)
+    metric_id = AutoIncrementField()
     name = CharField(max_length=120, unique=True)
     units = CharField(max_length=24, null=True)
     upper_limit = FloatField(null=True)
@@ -82,7 +83,7 @@ class DataPoint(DataModel):
     naive :class:`datetime.datetime` objects (no timezone info).
     """
 
-    datapoint_id = IntegerField(primary_key=True)
+    datapoint_id = AutoIncrementField()
     metric = ForeignKeyField(Metric, backref="datapoints",
                              on_delete="CASCADE")
     value = FloatField()


### PR DESCRIPTION
This modifies the database to force use of SQLite's `AUTOINCREMENT` keyword.

Note that this will create some slight overhead: https://www.sqlite.org/autoinc.html. However, I don't expect it to be a major issue given the amount of data I expect this program to handle.

This is needed because `db.insert_datapoint` is not returning the `datapoint_id` and I can't bloody figure out why. All I know is that this solves things.