### PR TITLE
Add 'depends_on' to docker-compose files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   internal `ROWID`. This will result in increased cpu/memory/disk overhead,
   but it ensures that PKs cannot be resued. (#143)
 + The REST API for `DataPoint` has been implemented. (#122)
++ Example `docker-compose.yml` file now includes `depends_on`. (#99)
 
 
 ## 0.5.0 (2019-02-28)

--- a/docker-build.yml
+++ b/docker-build.yml
@@ -23,10 +23,14 @@ services:
       - type: bind
         source: c:/gitlab/github/trendlines/internal.db
         target: /data/internal.db
+    depends_on:
+      - "celery"
+
   redis:
     image: redis
     ports:
       - "6379:6379"
+
   celery:
     build:
       context: .
@@ -42,3 +46,5 @@ services:
         # `trendlines.cfg`.
         target: /data
     command: celery worker -l info -A trendlines.celery_app.celery
+    depends_on:
+      - "redis"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,10 +18,14 @@ services:
         # database file (if you're using SQLite) and the configuration file
         # `trendlines.cfg`.
         target: /data
+    depends_on:
+      - "celery"
+
   redis:
     image: redis
     ports:
       - "6379:6379"
+
   celery:
     image: dougthor42/trendlines:latest
     ports:
@@ -32,3 +36,5 @@ services:
         source: /var/www/trendlines
         target: /data
     command: celery worker -l info -A trendlines.celery_app.celery
+    depends_on:
+      - "celery"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -148,3 +148,5 @@ Add the following services to your ``docker-compose.yml``:
          source: /var/www/trendlines
          target: /data
      command: celery worker -l info -A trendlines.celery_app.celery
+     depends_on:
+       - "redis"


### PR DESCRIPTION
Fixes #99:

+ Add `depends_on` to example `docker\docker-compose.yml` file.
+ Add `depends_on` to `docker-build.yml` file.
+ Updated `installation.rst` docs to include `depends_on` in "Running with
  Celery" section.
+ Update changelog