### PR TITLE
Use internal ids for jstree

### DIFF
--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -62,7 +62,7 @@ def index():
     Displays a list of all the known metrics with links.
     """
     raw_data = db.get_metrics()
-    data = utils.build_jstree_data(m.name for m in raw_data)
+    data = utils.build_jstree_data(raw_data)
     return render_template("trendlines/index.html", data=data)
 
 

--- a/src/trendlines/static/core.js
+++ b/src/trendlines/static/core.js
@@ -25,8 +25,8 @@ function populateTree(data) {
     // jsTree puts the original data structure in a nested object
     // called 'original'. How original of them. Hahaha I crack myself up.
     // If `url` is defined, take us there.
-    if (data.node.original.url !== null) {
-      var expected = data.node.original.url;
+    if (data.node.original.metric_id !== null) {
+      var expected = "/plot/" + data.node.original.id;
       var new_href = document.location.origin + expected;
 
       // Take the user to the plot page.

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -67,7 +67,7 @@ def get_metric_parent(metric):
 
 def format_metric_for_jstree(metric):
     """
-    Format a metric name into a dict consumable by jsTree.
+    Format a metric into a dict consumable by jsTree.
 
     See "Alternative JSON format" in the `jsTree docs`_.
 
@@ -75,17 +75,23 @@ def format_metric_for_jstree(metric):
 
     Parameters
     ----------
-    metric : str
-        The metric name to format.
+    metric : :class:`trendlines.orm.Metric`
+        The metric to format.
 
     Returns
     -------
     dict
-        A dict with the following keys: id, parent, text, url
+        A dict with the following keys: id, parent, text, metric_id
     """
-    parent = get_metric_parent(metric)
-    url = url_for('pages.plot', metric=metric)
-    return {"id": metric, "parent": parent, "text": metric, "url": url}
+    metric_name = metric.name
+    parent = get_metric_parent(metric_name)
+    jstree_node = {
+        "id": metric_name,
+        "parent": parent,
+        "text": metric_name,
+        "metric_id": metric.metric_id,
+    }
+    return jstree_node
 
 
 def build_jstree_data(metrics):

--- a/src/trendlines/utils.py
+++ b/src/trendlines/utils.py
@@ -102,20 +102,26 @@ def build_jstree_data(metrics):
 
     Parameters
     ----------
-    metrics : list of str
-        The metric names to display. Note that this is *not* the Metric
-        objects themselves, but rather a simple list of strings (metric
-        names). Take the results of :func:`db.get_metrics`::
+    metrics : list of :class:`trendlines.orm.Metric` objects
+        Changed in v0.6.0: this is now :class:`~trendlines.orm.Metric` objects
+        and **not** the metric names:
+
+        .. code-block:: python
 
            raw_data = db.get_metrics()
+
+           # Before v0.6.0
            tree = build_jstree_data(m.name for m in raw_data)
+
+           # v0.6.0:
+           tree = build_jstree_data(raw_data)
 
     Returns
     -------
     data : list of dict
         A JSON-serializable list of dicts. Each dict has at least ``id`` and
         ``parent`` keys. If the metric doesn't exist (it's just a placeholder
-        parent), then the value of the ``url`` key will be ``None``.
+        parent), then the value of the ``metric_id`` key will be ``None``.
 
     Notes
     -----
@@ -132,11 +138,11 @@ def build_jstree_data(metrics):
        # Spacing added for readability
        # The `text` key is removed for readabiity.
        [
-        {"id": "foo",         "parent": "#",       "url": "/plot/foo"         },
-        {"id": "foo.bar",     "parent": "foo",     "url": "/plot/foo.bar"     },
-        {"id": "bar",         "parent": "#",       "url": None                },
-        {"id": "bar.baz",     "parent": "bar",     "url": None                },
-        {"id": "bar.baz.biz", "parent": "bar.baz", "url": "/plot/bar.baz.biz" },
+        {"id": "foo",         "parent": "#",       "metric_id": 1    },
+        {"id": "foo.bar",     "parent": "foo",     "metric_id": 2    },
+        {"id": "bar",         "parent": "#",       "metric_id": None },
+        {"id": "bar.baz",     "parent": "bar",     "metric_id": None },
+        {"id": "bar.baz.biz", "parent": "bar.baz", "metric_id": 3    },
        ]
     """
     # First go through and make all of our existing links
@@ -159,7 +165,7 @@ def build_jstree_data(metrics):
         new = {"id": m['parent'],
                "parent": new_parent,
                "text": m['parent'],
-               "url": None,
+               "metric_id": None,
                }
         data.append(new)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from flask import current_app
 from flask import Response
 from freezegun import freeze_time
 
+from trendlines import orm
 from trendlines import utils
 from .test_orm import _hash_file
 
@@ -31,13 +32,13 @@ def test_get_metric_parent(metric, expected):
 
 
 @pytest.mark.parametrize("data, expected", [
-    ("foo", {"id": "foo", "parent": "#", "text": "foo",
-             "url": "/plot/foo"}),
-    ("foo.bar", {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-                 "url": "/plot/foo.bar"}),
-    ("foo.bar.baz", {"id": "foo.bar.baz", "parent": "foo.bar",
-                     "text": "foo.bar.baz",
-                     "url": "/plot/foo.bar.baz"}),
+    (orm.Metric(metric_id=1, name="foo"),
+     {"id": "foo", "parent": "#", "text": "foo", "metric_id": 1}),
+    (orm.Metric(metric_id=2, name="foo.bar"),
+     {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "metric_id": 2}),
+    (orm.Metric(metric_id=3, name="foo.bar.baz"),
+     {"id": "foo.bar.baz", "parent": "foo.bar", "text": "foo.bar.baz",
+      "metric_id": 3}),
 ])
 def test_format_metric_for_jstree(test_request_context, data, expected):
     rv = utils.format_metric_for_jstree(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,37 +46,41 @@ def test_format_metric_for_jstree(test_request_context, data, expected):
 
 
 @pytest.mark.parametrize("metrics, expected", [
-    (["foo", "foo.bar"], [
+    ([orm.Metric(metric_id=1, name="foo"),
+      orm.Metric(metric_id=2, name="foo.bar")], [
         {"id": "foo", "parent": "#", "text": "foo",
-         "url": "/plot/foo"},
+         "metric_id": 1},
         {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-         "url": "/plot/foo.bar"},
+         "metric_id": 2},
         ]
      ),
-    (["foo.bar.baz"], [
-        {"id": "foo", "parent": "#", "text": "foo", "url": None},
-        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "url": None},
+    ([orm.Metric(metric_id=1, name="foo.bar.baz")], [
+        {"id": "foo", "parent": "#", "text": "foo", "metric_id": None},
+        {"id": "foo.bar", "parent": "foo", "text": "foo.bar", "metric_id": None},
         {"id": "foo.bar.baz", "parent": "foo.bar", "text": "foo.bar.baz",
-         "url": "/plot/foo.bar.baz"},
+         "metric_id": 1},
         ]
      ),
-    (["foo.bar", "foo.baz"], [
-        {"id": "foo", "parent": "#", "text": "foo", "url": None},
+    ([orm.Metric(metric_id=1, name="foo.bar"),
+      orm.Metric(metric_id=2, name="foo.baz")], [
+        {"id": "foo", "parent": "#", "text": "foo", "metric_id": None},
         {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-         "url": "/plot/foo.bar"},
+         "metric_id": 1},
         {"id": "foo.baz", "parent": "foo", "text": "foo.baz",
-         "url": "/plot/foo.baz"},
+         "metric_id": 2},
         ]
      ),
-    (["foo", "foo.bar", "bar.baz.biz"], [
-        {"id": "bar", "parent": "#", "text": "bar", "url": None},
-        {"id": "bar.baz", "parent": "bar", "text": "bar.baz", "url": None},
+    ([orm.Metric(metric_id=1, name="foo"),
+      orm.Metric(metric_id=2, name="foo.bar"),
+      orm.Metric(metric_id=3, name="bar.baz.biz")], [
+        {"id": "bar", "parent": "#", "text": "bar", "metric_id": None},
+        {"id": "bar.baz", "parent": "bar", "text": "bar.baz", "metric_id": None},
         {"id": "bar.baz.biz", "parent": "bar.baz", "text": "bar.baz.biz",
-         "url": "/plot/bar.baz.biz"},
+         "metric_id": 3},
         {"id": "foo", "parent": "#", "text": "foo",
-         "url": "/plot/foo"},
+         "metric_id": 1},
         {"id": "foo.bar", "parent": "foo", "text": "foo.bar",
-         "url": "/plot/foo.bar"},
+         "metric_id": 2},
        ]
      )
 ])


### PR DESCRIPTION
This changes the data structure of the jstree data to use internal IDs instead of a url. It's needed for a future MR for #58.

+ `format_metric_for_jstree` now:
    + accepts a `Metric` object instead of a string
    + replaces the `url` key in the returned dict with `metric_id`
+ `build_jstree_data`
    + accept list of `Metric` objects instead of strings
    + update return dict for nullable `metric_id` key
+ Update routes and JS to account for the above changes.
+ Update docs, tests