### PR TITLE
Integration tests via docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 ## Unreleased
++ Integration tests (via docker-compose) were added. (#165)
++ Supposedly fixed an issue that occurs when running behind a proxy (#162).
 
 
 ## 0.6.0b2 (2019-06-27)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ coveralls==1.5.1
 wheel==0.32.3
 pdbpp==0.9.3
 sphinx==1.7.9
+docker==4.0.2
+pytest-docker==0.6.1

--- a/src/trendlines/routes.py
+++ b/src/trendlines/routes.py
@@ -12,8 +12,9 @@ from flask import render_template as _render_template
 from flask import request
 from flask.views import MethodView
 
-from flask_rest_api import Api
+from flask_rest_api import Api as _Api
 from flask_rest_api import Blueprint
+from werkzeug.routing import RoutingException
 
 # peewee
 from peewee import DoesNotExist
@@ -29,6 +30,17 @@ from .error_responses import ErrorResponse
 from . import utils
 
 pages = FlaskBlueprint('pages', __name__)
+
+
+# https://github.com/Nobatek/flask-rest-api/issues/51
+class Api(_Api):
+    def handle_http_exception(self, error):
+        # Don't serialize redirects
+        if isinstance(error, RoutingException):
+            return error
+        return super().handle_http_exception(error)
+
+
 api_class = Api()
 api = Blueprint("api", __name__,
                 description="All API.")

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,74 @@
+# This Dockerfile creates a dummy host that mimics my typical
+# setup for Apache2 and proxied services.
+
+FROM "ubuntu:18.04" as ubuntu-docker-apache
+
+LABEL maintainer="doug.thor@gmail.com"
+
+RUN apt update \
+    && apt install -y \
+        apache2 \
+        # Docker prereqs
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common
+
+# Docker
+RUN curl \
+        -fsSL \
+        https://download.docker.com/linux/ubuntu/gpg \
+        | apt-key add - \
+    && add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) \
+        stable" \
+    && apt update \
+    # Installing docker takes a long time because many dependencies are
+    # missing from our base image.
+    && apt install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io
+
+# Install docker-compose
+# Technically it's not needed because the test runner is actually
+# using the compose file, but this helps mimic a live server.
+RUN curl \
+        -L \
+        "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" \
+        -o \
+        /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 80
+
+# Run apache in the foreground
+CMD ["apache2ctl", "-D", "FOREGROUND", "-e", "INFO"]
+
+
+# Now that we have a base "server", we install our application
+# on it. This should match closely with the docker-compose installation
+# instructions.
+FROM ubuntu-docker-apache
+
+RUN mkdir -p /var/www/trendlines
+
+RUN apt update && apt install -y vim
+RUN apt install -y dnsutils iputils-ping less
+RUN echo foo
+
+COPY integration/apache.conf /etc/apache2/sites-available/main.conf
+COPY integration/trendlines.cfg /var/www/trendlines/trendlines.cfg
+
+RUN chown www-data:www-data /var/www/trendlines \
+    && a2ensite main.conf \
+    && a2enmod proxy \
+    && a2enmod proxy_http \
+    && a2enmod headers \
+    && a2dissite 000-default.conf \
+    && service apache2 restart

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,60 @@
+#
+# Docker-compose file used when running integration tests.
+#
+
+# Need version >= 3.2 because of how we define our volumes
+version: "3.2"
+services:
+  host:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: example-host:pytest
+    ports:
+      - 5000:80
+    volumes:
+      - type: volume
+        source: host_install_loc
+        target: /var/www/trendlines
+
+  trendlines:
+    build:
+      context: ../.
+      dockerfile: docker/Dockerfile
+    image: trendlines:pytest
+    expose:
+      - 80
+    volumes:
+      - type: volume
+        source: host_install_loc
+        target: /data
+    depends_on:
+      - celery
+      - redis
+
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    depends_on:
+      - host
+
+  celery:
+    build:
+      context: ../.
+      dockerfile: docker/Dockerfile
+    image: trendlines:pytest
+    ports:
+      - "2003:2003"
+    volumes:
+      - type: volume
+        source: host_install_loc
+        target: /data
+    command: celery worker -l info -A trendlines.celery_app.celery
+    depends_on:
+      - redis
+
+# This volume mimics the trendlines stack runnning
+# inside the host.
+volumes:
+  host_install_loc:

--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -1,0 +1,16 @@
+# This is a basic apache virtual host file used within a dummy container.
+
+<VirtualHost *:80>
+	ServerName pytest-container
+
+	<Location /trendlines>
+		ProxyPreserveHost On
+		ProxyPass http://trendlines/trendlines
+		ProxyPassReverse http://trendlines/trendlines
+
+		RequestHeader set X-Forwarded-Port 80
+	</Location>
+
+</VirtualHost>
+
+# vim: syntax=apache tabstop=4 shiftwidth=4 softtabstop=4 shiftround noexpandtab

--- a/tests/integration/trendlines.cfg
+++ b/tests/integration/trendlines.cfg
@@ -1,0 +1,4 @@
+DATABASE = "/data/internal.db"
+URL_PREFIX = "/trendlines"
+
+SECRET_KEY = "Not a secret"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+"""
+import tarfile
+from collections import namedtuple
+from datetime import datetime as dt
+from io import BytesIO
+from pathlib import Path
+
+import freezegun
+import pytest
+import requests
+
+BASE_URL = "http://localhost:5000/trendlines"
+API_URL = BASE_URL + "/api/v1"
+
+
+Data = namedtuple('Data', ['name', 'value', 'timestamp'])
+
+DUMMY_DATA = [
+    Data("foo.bar", 12.34, "2019-07-07 15:26:34"),
+    Data("foo.bar", 12.96, "2019-07-07 15:26:35"),
+    Data("foo.bar", 13.50, "2019-07-07 15:26:36"),
+    Data("baz", -19, "2019-07-07 15:26:34"),
+    Data("baz", -19.1, "2019-07-07 15:26:35"),
+]
+
+
+# I don't like that this uses the API that I'm trying to test.
+# But I also don't feel like resolving that right now.
+@pytest.fixture(scope="module", autouse=True)
+def add_data(docker_services):
+    for d in DUMMY_DATA:
+        data = {
+            "metric": d.name,
+            "value": d.value,
+            "timestamp": d.timestamp,
+        }
+        requests.post(API_URL + "/data", json=data)
+
+
+@pytest.mark.parametrize("url", [
+    BASE_URL,
+    BASE_URL + "/api",
+    BASE_URL + "/api/redoc",
+    BASE_URL + "/plot/1",
+    API_URL + "/data/1",     # route supports GET by name or ID
+    API_URL + "/data/foo.bar",
+    API_URL + "/metric",
+    API_URL + "/metric/1",
+    API_URL + "/datapoint",
+    API_URL + "/datapoint/1",
+])
+def test_url_prefix(url):
+    # Test that various routes work correctly when URL_PREFIX is
+    # set and we're behind a proxy.
+    rv = requests.get(url)
+    assert rv.status_code == 200
+
+
+def test_api_get_data():
+    rv = requests.get(API_URL + "/data/foo.bar")
+    assert rv.status_code == 200
+    rows = rv.json()['rows']
+    assert len(rows) == 3
+    assert rows[0]['value'] == 12.34
+
+    rv_by_id = requests.get(API_URL + "/data/1")
+    assert rv_by_id.json() == rv.json()
+
+
+def test_api_get_metric():
+    rv = requests.get(API_URL + "/metric")
+    assert rv.status_code == 200
+    json = rv.json()
+    assert set(json.keys()) == {'count', 'next', 'prev', 'results'}
+    results = json['results']
+    assert len(results) == 2
+    assert json['count'] == len(results)
+    assert results[1]['name'] == 'baz'
+
+    rv_2 = requests.get(API_URL + "/metric/2")
+    assert rv_2.json() == results[1]
+
+
+def test_api_get_datapoint():
+    rv = requests.get(API_URL + "/datapoint")
+    assert rv.status_code == 200
+    json = rv.json()
+    assert set(json.keys()) == {'count', 'next', 'prev', 'results'}
+    results = json['results']
+    assert len(results) == 5
+    assert json['count'] == len(results)
+    assert results[3]['value'] == -19
+
+
+@pytest.mark.skip(reason=("Need a reliable way to check that the plot has"
+                          " actually been displayed. Perhaps Selenium"))
+def test_plot_page():
+    rv = request.get(BASE_URL + "/plot/1")
+    assert rv.status_code == 200
+    assert 'var metricId = "foo.bar"' in rv.text


### PR DESCRIPTION
This adds integration tests which verify how things should work when running with the recommended compose file and behind a proxy.