### PR TITLE
Fix api behind proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## Unreleased
 + Integration tests (via docker-compose) were added. (#165)
 + Supposedly fixed an issue that occurs when running behind a proxy (#162).
++ *Actually* fixed the issue where the plots wouldn't show when `URL_PREFIX`
+  was set (running behind a proxy). (#162).
+  + Of course, there's another part which is **not** fixed (#168)
 
 
 ## 0.6.0b2 (2019-06-27)

--- a/src/trendlines/static/core.js
+++ b/src/trendlines/static/core.js
@@ -1,7 +1,7 @@
 /**
  * Populate the JSTree tree.
  */
-function populateTree(data, metricId) {
+function populateTree(data, metricId, urlPrefix) {
   var tree = $('#jstree-div');
 
   // Create an instance when the DOM is ready.
@@ -35,7 +35,7 @@ function populateTree(data, metricId) {
 
   // Update the plot or toggle the node open/closed.
   tree.on('select_node.jstree', function(e, data) {
-    treeChanged(e, data);
+    treeChanged(e, data, urlPrefix);
   });
 };
 
@@ -44,17 +44,22 @@ function populateTree(data, metricId) {
  * Update the plot if data exists, otherwise just open the tree.
  * This is called when the `select_node` event is seen.
  */
-function treeChanged(e, data) {
+function treeChanged(e, data, urlPrefix) {
   // If `metric_id` is defined, then we can query data
   if (data.node.original.metric_id !== null) {
-    var expected = "/api/v1/data/" + data.node.original.metric_id;
+
+    // Stupid f-ing javascript... urlPrefix can be `null`, which when concatenated
+    // with a string, gets cast to the string 'null'. So we get "null/api/..."
+    urlPrefix = urlPrefix || ""
+
+    var expected = urlPrefix + "/api/v1/data/" + data.node.original.metric_id;
     // grab the plot data from the api
     $.getJSON(expected)
       .done(function(jsonData) {
         makePlot(jsonData);
 
         // This updates the URL to reflect which plot is shown.
-        var history_url = "/plot/" + data.node.original.metric_id;
+        var history_url = urlPrefix + "/plot/" + data.node.original.metric_id;
         window.history.pushState('page2', 'Title', history_url);
       })
       .fail(function(jqXHR, textStatus, errorThrown) {

--- a/src/trendlines/templates/trendlines/index.html
+++ b/src/trendlines/templates/trendlines/index.html
@@ -9,8 +9,8 @@
       <h4>v{{ version }}</h4>
       <div id="apiLinks">
         <ul>
-          <li><a target="_blank" href="/api/">API Reference (Swagger)</a></li>
-          <li><a target="_blank" href="/api/redoc">API Reference (ReDoc)</a></li>
+          <li><a target="_blank" href="{{ config.get('URL_PREFIX', '') }}/api/">API Reference (Swagger)</a></li>
+          <li><a target="_blank" href="{{ config.get('URL_PREFIX', '') }}/api/redoc">API Reference (ReDoc)</a></li>
         </ul>
       </div>
     </div>
@@ -28,7 +28,7 @@
 
           // Populate the jsTree with the metric names.
           var metricId = {{ metric_id | tojson | safe }};
-          populateTree(treeData, metricId);
+          populateTree(treeData, metricId, {{ config.get('URL_PREFIX', None) | tojson | safe }});
         });
       </script>
     </div>


### PR DESCRIPTION
This fixes the plots showing up when running behind a proxy (`URL_PREFIX != None`), finally causing the application to be usable again, yay!

Fixes #162.

Only HTML and JS updates were needed.