### PR TITLE
Pin more reqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   was set (running behind a proxy). (#162).
   + Of course, there's another part which is **not** fixed (#168)
 + Redis was pinned at v5.0.5-alpine. (#163)
++ Added `marshmallow` to `requirements.txt` and pinned it. Also added and
+  pinned `attrs==18.2` in `requirements-dev.txt because of an issue with
+  pytest. See https://stackoverflow.com/a/58189684/1354930. (#175)
 
 
 ## 0.6.0b2 (2019-06-27)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs==18.2
 pytest==4.0.2
 coverage==4.5.2
 pytest-cov==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ requests==2.21.0
 celery[redis]==4.2.1
 peewee-moves==2.0.1
 loguru==0.2.5
+marshmallow==2.19.5
 marshmallow-peewee==2.2.0
 flask-rest-api==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ long_descr = Path("./README.md").read_text()
 requires = [
     "flask>=1.0",
     "peewee>=3.8",
+    "marshmallow>=2.19,<3.0",
+    "apispec>=2,<3",
+    "pip>=18",
 ]
 
 setup(


### PR DESCRIPTION
This pins more of the python requirements.

Really I ought to (a) update everything and then (b) pin it all, but I want to get this pushed out quickly.

Fixes #175 
